### PR TITLE
 Correct bug with unconfirmed txs 

### DIFF
--- a/src/discovery/worker/inside/index.js
+++ b/src/discovery/worker/inside/index.js
@@ -13,6 +13,17 @@ import type {BlockRange, AccountNewInfo} from '../types';
 import {GetChainTransactions} from './get-chain-transactions';
 import {integrateNewTxs} from './integrate-new-txs';
 
+// increase version for forced redownload of txs
+// (on either format change, or on some widespread data corruption)
+//
+// version 1 added infos about fees and sizes; we cannot calculate that
+// version 2 was correction in mytrezor
+// v3 added info, whether utxo is my own or not
+// so we have to re-download everything -> setting initial state as if nothing is known
+// v4 changed timestamp format
+// v5 is just to force re-download on forceAdded data corruption
+const LATEST_VERSION = 5;
+
 // Default starting info being used, when there is null
 const defaultInfo: AccountInfo = {
     utxos: [],
@@ -28,7 +39,7 @@ const defaultInfo: AccountInfo = {
     allowChange: false,
     lastConfirmedChange: -1,
     lastConfirmedMain: -1,
-    version: 4,
+    version: LATEST_VERSION,
 };
 
 let recvInfo: ?AccountInfo;
@@ -70,11 +81,7 @@ channel.initPromise.then(({
 channel.startDiscoveryPromise.then(() => {
     let initialState = recvInfo == null ? defaultInfo : recvInfo;
 
-    // version null => 1 added infos about fees and sizes; we cannot calculate that
-    // version 2 was correction in mytrezor
-    // v3 added info, whether utxo is my own or not
-    // so we have to re-download everything -> setting initial state as if nothing is known
-    if (initialState.version == null || initialState.version < 4) {
+    if (initialState.version == null || initialState.version < LATEST_VERSION) {
         initialState = defaultInfo;
     }
 

--- a/src/discovery/worker/outside/index.js
+++ b/src/discovery/worker/outside/index.js
@@ -170,7 +170,7 @@ export class WorkerDiscoveryHandler {
                                 };
                                 if (transactions_.map(t => t.hash).some(hash => transaction.hash === hash)) {
                                     // transaction already came from blockchain again
-                                    this.forceAddedTransactions.slice(i, 1);
+                                    this.forceAddedTransactions.splice(i, 1);
                                 } else {
                                     const txAddresses = new Set();
                                     transaction.inputAddresses.concat(transaction.outputAddresses).forEach(a => {

--- a/test/discover-account.js
+++ b/test/discover-account.js
@@ -38,7 +38,7 @@ describe('discover account', () => {
                     }
                 }
             }, (err) => {
-                if (err !== fixture.endError) {
+                if (!(err.startsWith(fixture.endError))) {
                     console.log('Discovery result', JSON.stringify(err, null, 2));
                     console.log('Fixture', JSON.stringify(fixture.endError, null, 2));
                     done(new Error('Result not the same'));

--- a/test/fixtures/discover-account.json
+++ b/test/fixtures/discover-account.json
@@ -7315,7 +7315,7 @@
     "name": "Nonsensical tx",
     "start": null,
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
-    "endError": "Error transaction parsing: Index out of range",
+    "endError": "Error transaction parsing",
     "network": {
       "messagePrefix": "N/A",
       "bip32": {

--- a/test/fixtures/discover-account.json
+++ b/test/fixtures/discover-account.json
@@ -27,7 +27,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -119,7 +119,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -146,7 +146,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -247,7 +247,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -274,7 +274,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -375,7 +375,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -456,7 +456,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -629,7 +629,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -791,7 +791,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -872,7 +872,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -1043,7 +1043,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -1124,7 +1124,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -1295,7 +1295,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -1376,7 +1376,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -1548,7 +1548,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -1575,7 +1575,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -1734,7 +1734,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -1909,7 +1909,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -1991,7 +1991,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -2158,7 +2158,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -2240,7 +2240,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -2425,7 +2425,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -2543,7 +2543,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -2781,7 +2781,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -3025,7 +3025,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -3267,7 +3267,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -3385,7 +3385,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -3621,7 +3621,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -3703,7 +3703,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -3906,7 +3906,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -3987,7 +3987,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -4312,7 +4312,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -4518,7 +4518,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -4685,7 +4685,7 @@
         "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -4997,7 +4997,7 @@
         "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -5164,7 +5164,7 @@
         "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -5366,7 +5366,7 @@
         "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -5603,7 +5603,7 @@
         "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -5883,7 +5883,7 @@
         "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -6102,7 +6102,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -6302,7 +6302,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -6542,7 +6542,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -6780,7 +6780,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -6908,7 +6908,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -7079,7 +7079,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -7209,7 +7209,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",
@@ -7462,7 +7462,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
     "end": {
@@ -7599,7 +7599,7 @@
         "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
       ],
       "allowChange": true,
-      "version": 4
+      "version": 5
     },
     "network": {
       "messagePrefix": "N/A",


### PR DESCRIPTION
The forceAddTransaction was added, so that immediately after transaction send, user see the TX in his list, even when the backend didn't yet send the TX. This sometimes happened when the backend was too busy, so users didn't see their own transactions and had wrong UTXO sets.

The original intent was to add the TX to the array, but remove it once it has been seen in the stream from the backend.

However, there has been an error in the code and the TX did not get removed and stayed there until window reload. That means that the unconfirmed transaction always "overloaded" the confirmed one, so transactions stayed unconfirmed.

The bug is just `slice` being used instead of `splice`.

That was one problem - however, there was an additional consequence introduced later. In the recent update, hd-wallet removes unconfirmed transactions that haven't been seen in either recent update or in mempool. This would normally work - however, it broke when transaction was wrongly saved as unconfirmed, but it was not in the forceAddedTransaction array anymore (because that is only saved in memory)

This fixes both bugs - transactions are now displayed as confirmed when they are confirmed, and they are not removed on reload.

The other commit is just increasing the data version + making it slightly more explicit