### PR TITLE
Increase coverage, faster tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,11 @@
 {
   "presets": [
-    "es2015"
+    "@babel/preset-env"
   ],
   "plugins": [
-    "transform-flow-strip-types",
-    "transform-class-properties",
-    "transform-object-rest-spread",
-    "add-module-exports"
+    "@babel/plugin-transform-flow-strip-types",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread",
   ],
   "env": {
     "test": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,24 +70,26 @@ matrix:
 
 # ------------------- bitcore tests ---------------------
 
-    - env: TEST_SUITE=test-bitcore-with-docker
+    - env: TEST_SUITE=unit-bitcore-with-docker
       sudo: required
+
     - before_script:
         # we need to run xvfb fot the karma tests to work
         - export CHROME_BIN=chromium-browser
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start
         - mv karma_confs/karma.conf.js-bitcore karma.conf.js
+        - make bitcore-test-docker
       env: TEST_SUITE=karma-chrome TEST=bitcore-with-docker
       sudo: required
     - before_script:
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start
         - mv karma_confs/karma.conf.js-bitcore karma.conf.js
-      env: TEST_SUITE=karma-firefox TEST=bitcore
+        - make bitcore-test-docker
+      env: TEST_SUITE=karma-firefox TEST=bitcore-with-docker
       addons:
         firefox: latest
-      language: generic
       sudo: required
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -36,26 +36,23 @@ lib:
 	cd ./src && find . -name '*.js' | xargs -I {} cp {} ../lib/{}.flow
 
 unit:
-	`npm bin`/mocha --compilers js:babel-register
+	`npm bin`/mocha --compilers js:@babel/register
 
 unit-build-tx:
-	`npm bin`/mocha --compilers js:babel-register test/build-tx.js
+	`npm bin`/mocha --compilers js:@babel/register test/build-tx.js
 
 unit-discovery:
-	`npm bin`/mocha --compilers js:babel-register test/discover-account.js
+	`npm bin`/mocha --compilers js:@babel/register test/discover-account.js
 
 unit-bitcore:
-	`npm bin`/mocha --compilers js:babel-register test/test_bitcore/bitcore.js
+	`npm bin`/mocha --compilers js:@babel/register test/bitcore.js
 
 
 coverage-html:
-	NODE_ENV=test `npm bin`/nyc --reporter=html --check-coverage `npm bin`/mocha --compilers js:babel-register
+	NODE_ENV=test `npm bin`/nyc --cache --babel-cache=true --reporter=html --check-coverage `npm bin`/mocha --compilers js:@babel/register
 
 run-coverage:
-	NODE_ENV=test `npm bin`/nyc --check-coverage `npm bin`/mocha --compilers js:babel-register
-
-test-bitcore:
-	`npm bin`/mocha --compilers js:babel-register test/test_bitcore/bitcore.js
+	NODE_ENV=test `npm bin`/nyc --check-coverage --babel-cache=true `npm bin`/mocha --compilers js:@babel/register
 
 flow:
 	`npm bin`/flow check src

--- a/karma_confs/karma.conf.js-bitcore
+++ b/karma_confs/karma.conf.js-bitcore
@@ -14,18 +14,18 @@ module.exports = function (config) {
         browserify: {
             debug: true,
             transform: [
-                ['babelify', {
-                    'presets': [
-                        'es2015',
+                ['babelify', 
+                  {
+                    "presets": [
+                      "@babel/preset-env"
                     ],
-                    'plugins': [
-                        'transform-flow-strip-types',
-                        'transform-class-properties',
-                        'transform-object-rest-spread',
-                        'add-module-exports',
-                        'istanbul',
-                    ],
-                }],
+                    "plugins": [
+                      "@babel/plugin-transform-flow-strip-types",
+                      "@babel/plugin-proposal-class-properties",
+                      "@babel/plugin-proposal-object-rest-spread"
+                    ]
+                  }
+                ],
                 ['workerify'],
                 ['browserify-shim'],
             ],

--- a/karma_confs/karma.conf.js-buildtx
+++ b/karma_confs/karma.conf.js-buildtx
@@ -14,18 +14,18 @@ module.exports = function (config) {
         browserify: {
             debug: true,
             transform: [
-                ['babelify', {
-                    'presets': [
-                        'es2015',
+                ['babelify', 
+                  {
+                    "presets": [
+                      "@babel/preset-env"
                     ],
-                    'plugins': [
-                        'transform-flow-strip-types',
-                        'transform-class-properties',
-                        'transform-object-rest-spread',
-                        'add-module-exports',
-                        'istanbul',
-                    ],
-                }],
+                    "plugins": [
+                      "@babel/plugin-transform-flow-strip-types",
+                      "@babel/plugin-proposal-class-properties",
+                      "@babel/plugin-proposal-object-rest-spread"
+                    ]
+                  }
+                ],
                 ['workerify'],
                 ['browserify-shim'],
             ],

--- a/karma_confs/karma.conf.js-discovery
+++ b/karma_confs/karma.conf.js-discovery
@@ -14,18 +14,18 @@ module.exports = function (config) {
         browserify: {
             debug: true,
             transform: [
-                ['babelify', {
-                    'presets': [
-                        'es2015',
+                ['babelify', 
+                  {
+                    "presets": [
+                      "@babel/preset-env"
                     ],
-                    'plugins': [
-                        'transform-flow-strip-types',
-                        'transform-class-properties',
-                        'transform-object-rest-spread',
-                        'add-module-exports',
-                        'istanbul',
-                    ],
-                }],
+                    "plugins": [
+                      "@babel/plugin-transform-flow-strip-types",
+                      "@babel/plugin-proposal-class-properties",
+                      "@babel/plugin-proposal-object-rest-spread"
+                    ]
+                  }
+                ],
                 ['workerify'],
                 ['browserify-shim'],
             ],
@@ -34,6 +34,7 @@ module.exports = function (config) {
         // list of files / patterns to load in the browser
         files: [
             'test/discover-account.js',
+            'test/monitor-account.js',
             {pattern: 'fastxpub/build/fastxpub.js', included: false},
             {pattern: 'fastxpub/build/fastxpub.wasm', included: false}
 
@@ -46,8 +47,8 @@ module.exports = function (config) {
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
-            'test/bitcore.js': [ 'browserify' ],
             'test/discover-account.js': [ 'browserify' ],
+            'test/monitor-account.js': [ 'browserify' ],
         },
 
         // test results reporter to use

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "unit": "make unit",
     "unit-build-tx": "make unit-build-tx",
     "unit-discovery": "make unit-discovery",
-    "test-bitcore": "make test-bitcore",
+    "unit-bitcore-with-docker": "make bitcore-test-docker && make unit-bitcore",
+    "unit-bitcore": "make unit-bitcore",
     "coverage-html": "make coverage-html",
     "coverage": "make run-coverage",
     "flow": "make flow",
@@ -18,7 +19,6 @@
     "karma-firefox": "make karma-firefox",
     "karma-chrome": "make karma-chrome",
     "bitcore-test-docker": "make bitcore-test-docker",
-    "test-bitcore-with-docker": "make bitcore-test-docker && make test-bitcore",
     "coverage-with-docker": "make bitcore-test-docker && make run-coverage"
   },
   "author": "TREZOR <info@trezor.io>",
@@ -30,13 +30,12 @@
         "babelify",
         {
           "presets": [
-            "es2015"
+            "@babel/preset-env"
           ],
           "plugins": [
-            "transform-flow-strip-types",
-            "transform-class-properties",
-            "transform-object-rest-spread",
-            "add-module-exports"
+            "@babel/plugin-transform-flow-strip-types",
+            "@babel/plugin-proposal-class-properties",
+            "@babel/plugin-proposal-object-rest-spread"
           ]
         }
       ]
@@ -49,8 +48,8 @@
   "browserify-shim": {
     "../../../src/socketio-worker/inside.js": "global:thisIsJustForKarmaTestButIHaveToWriteItHere"
   },
+  "browserslist": "> 5%, IE > 9, last 10 versions",
   "dependencies": {
-    "babel-cli": "^6.26.0",
     "bchaddrjs": "^0.2.1",
     "bitcoinjs-lib-zcash": "^3.5.2",
     "queue": "^4.4.2",
@@ -58,15 +57,16 @@
     "whatwg-fetch": "^0.11.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.2.0",
+    "@babel/core": "^7.2.0",
+    "@babel/plugin-proposal-class-properties": "^7.2.1",
+    "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+    "@babel/plugin-transform-flow-strip-types": "^7.2.0",
+    "@babel/preset-env": "^7.2.0",
+    "@babel/register": "^7.0.0",
     "babel-eslint": "^7.2.1",
-    "babel-plugin-istanbul": "^4.1.6",
-    "babel-plugin-add-module-exports": "0.1.2",
-    "babel-plugin-transform-class-properties": "6.4.0",
-    "babel-plugin-transform-flow-strip-types": "6.4.0",
-    "babel-plugin-transform-object-rest-spread": "6.3.13",
-    "babel-preset-es2015": "6.3.13",
-    "babel-register": "^6.24.1",
-    "babelify": "7.2.0",
+    "babel-plugin-istanbul": "^5.1.0",
+    "babelify": "^10.0.0",
     "browserify": "^14.0.0",
     "browserify-shim": "^3.8.14",
     "eslint": "^3.19.0",
@@ -83,7 +83,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "mocha": "^3.1.0",
-    "nyc": "^8.1.10",
+    "nyc": "^13",
     "tiny-worker": "^2.0.3",
     "uglifyify": "3.0.1",
     "virtual-dom": "2.1.1",

--- a/src/discovery/worker-discovery.js
+++ b/src/discovery/worker-discovery.js
@@ -110,7 +110,7 @@ export class WorkerDiscovery {
     ): StreamWithEnding<AccountLoadStatus, AccountInfo> {
         const node = this.tryHDNode(xpub, network);
         if (node instanceof Error) {
-            return StreamWithEnding.fromStreamAndPromise(Stream.fromArray([]), Promise.reject(node));
+            return StreamWithEnding.fromStreamAndPromise(Stream.empty(), Promise.reject(node));
         }
 
         return StreamWithEnding.fromPromise(

--- a/src/discovery/worker/outside/channel.js
+++ b/src/discovery/worker/outside/channel.js
@@ -83,7 +83,7 @@ export class WorkerChannel {
                     });
                 }
                 if (message.type === 'error') {
-                    reject(message.error);
+                    reject(new Error(message.error));
                     detach();
                     onFinish();
                     this.w.then(w => {

--- a/src/discovery/worker/outside/index.js
+++ b/src/discovery/worker/outside/index.js
@@ -75,7 +75,10 @@ export class WorkerDiscoveryHandler {
         });
         this.workerChannel.postToWorker({type: 'startDiscovery'});
 
-        const promise = this.workerChannel.resPromise(() => this.counter.finisher.emit());
+        const promise = this.workerChannel.resPromise(() => {
+            this.counter.finisher.emit();
+            this.counter.stream.dispose();
+        });
 
         const stream: Stream<AccountLoadStatus> = this.counter.stream;
 

--- a/src/discovery/worker/outside/index.js
+++ b/src/discovery/worker/outside/index.js
@@ -146,7 +146,7 @@ export class WorkerDiscoveryHandler {
     ): Stream<ChunkDiscoveryInfo | string> {
         const addressPromise = WorkerDiscoveryHandler.deriveAddresses(source, addresses, firstIndex, lastIndex);
 
-        return Stream.fromPromise(
+        const errStream: Stream<ChunkDiscoveryInfo | string | Error> = Stream.fromPromise(
             addressPromise.then(addresses => {
                 if (this.cashAddress) {
                     addresses = addresses.map(a => bchaddrjs.toCashAddress(a));
@@ -195,6 +195,13 @@ export class WorkerDiscoveryHandler {
                 );
             })
         );
+        const resStream: Stream<ChunkDiscoveryInfo | string> = errStream.map((k: (ChunkDiscoveryInfo | string | Error)): (ChunkDiscoveryInfo | string) => {
+            if (k instanceof Error) {
+                return k.message;
+            }
+            return k;
+        });
+        return resStream;
     }
 }
 

--- a/test/_worker-helper.js
+++ b/test/_worker-helper.js
@@ -5,13 +5,13 @@ export const discoveryWorkerFactory = () => {
         const TinyWorker = require('tiny-worker');
 
         return new TinyWorker(() => {
-            require('babel-register');
             // Terrible hack
             // Browserify throws error if I don't do this
             // Maybe it could be fixed with noParse instead of eval, but I don't know how,
             // since this is all pretty hacky anyway
             // eslint-disable-next-line no-eval
             const requireHack = eval('req' + 'uire');
+            requireHack('@babel/register')({cache: true});
             requireHack('../../../src/discovery/worker/inside/index.js');
         });
     } else {

--- a/test/fixtures/monitor-account.json
+++ b/test/fixtures/monitor-account.json
@@ -1,0 +1,9797 @@
+[
+  {
+    "name": "Initializes empty account out of xpub",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f",
+        "height": 100
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 100
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 100,
+          "resultError": false,
+          "result": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 100,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 100,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Re-nitializes empty account out of xpub, no news",
+    "start": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f",
+        "height": 100
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f",
+        "height": 100
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 100
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 100,
+          "resultError": false,
+          "result": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 100,
+          "resultError": false,
+          "result": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 100,
+          "end": 100,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 100,
+          "end": 100,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Re-initializes empty account out of xpub, new block",
+    "start": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f",
+        "height": 100
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 100,
+          "resultError": false,
+          "result": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 100,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 100,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One unconfirmed tx, from initialized",
+    "start": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f",
+        "height": 100
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 100,
+          "resultError": false,
+          "result": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 100,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 100,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One unconfirmed tx, from empty",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One unconfirmed tx, from itself",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 101,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 101,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One unconfirmed tx, from one with orphaned block",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "00000000000deadc0ffee",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One unconfirmed tx, from one with orphaned block on longer chain",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "00000000000deadc0ffee",
+        "height": 102
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 102,
+          "resultError": false,
+          "result": ""
+        },
+        "comment": "note - bitcore returns RPC error, while blockbook returns empty hash"
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Orphaned block reverts unconfirmed",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "00000000000deadc0ffee",
+        "height": 102
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [],
+      "transactions": [],
+      "usedAddresses": [],
+      "unusedAddresses": [
+        "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "000000000000deadbeef",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 102,
+          "resultError": false,
+          "result": ""
+        },
+        "comment": "note - bitcore returns RPC error, while blockbook returns empty hash"
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One confirmed tx, from empty",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One confirmed tx, state preserves itself, no news",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead202",
+        "height": 202
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 202
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 202,
+          "resultError": false,
+          "result": "000000000000dead202"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 202,
+          "end": 200,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 202,
+          "end": 200,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 202,
+          "end": 200,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Unconfirmed -> confirmed",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead101",
+        "height": 101
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead202",
+        "height": 202
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 202
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 202,
+          "resultError": false,
+          "result": "000000000000dead202"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000dead101"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 202,
+          "end": 101,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 202,
+          "end": 0,
+          "result": [],
+          "note": "The newly uncovered address needs to be searched from the start!"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 202,
+          "end": 101,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in confirmed -> in confirmed, out unconfirmed",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead202",
+        "height": 202
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 202,
+          "resultError": false,
+          "result": "000000000000dead202"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "null -> in confirmed, out unconfirmed, one order incoming",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            },
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "null -> in confirmed, out unconfirmed, diff order incoming",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            },
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "in confirmed, out unconfirmed preserves itself",
+    "start": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "in confirmed, out unconfirmed; removed unc from mempool",
+    "start": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in, out unconfirmed; removed in from mempool",
+    "start": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+      ],
+      "lastConfirmedMain": -1,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": [
+            {
+              "hex": "02000000010aba74721637fe2eafe71ee156224d1018fc9c2be926a7d120b74a4b1970853c010000006b48304502210081495507441c4288798e0923224e376995f09600e81c43c68ff72286ae5b4c7002202b57356a40b7163ec9466a933dd18fd9abd786fdac608f9dd5d9cda5d54386be012103e63afb430725f25643ec3d94516bc4dc4cacebd6dfcbf91083dedcfdcfa9014efeffffff0280a4bf07000000001976a914a579388225827d9f2fe9014add644487808c695d88ac4c070436000000001976a9148785ac61c65f2e02f97231d817c4542572d0fbff88ac39971400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in 2 confirmed, out 1 unconfirmed; removed unc from mempool",
+    "start": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        },
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fbb",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fbb",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba00",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 260000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 293333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fbb",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        },
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fbb",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba00",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 260000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 260000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 260000000,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in confirmed, out 2 unconfirmed same address; removed one both unconf from mempool -> back to 2 utxo",
+    "start": {
+      "utxos": [],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a922",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 100000000,
+              "i": 1
+            }
+          ],
+          "type": "sent",
+          "value": -100000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 1
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 0
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 30000000,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -30000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 100000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a920",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 30000000,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -30000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 100000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 100000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        },
+        {
+          "index": 0,
+          "value": 30000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in confirmed, out 2 unconfirmed same address; removed one both unconf from mempool -> back to 2 utxo; the removed has also different input from same tx",
+    "start": {
+      "utxos": [],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a922",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 120000000,
+              "i": 1
+            }
+          ],
+          "type": "sent",
+          "value": -100000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 1
+            },
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 5
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 0
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 30000000,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -30000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 100000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a920",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 30000000,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -30000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 100000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 100000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        },
+        {
+          "index": 0,
+          "value": 30000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 101,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 30000000,
+              "i": 0
+            },
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "spending change; then removing the spend from mempool",
+    "start": {
+      "utxos": [],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158aaaa",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 100,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -33333333,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "index": 1
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 0
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1530847194,
+          "dateInfoDayFormat": "2018-07-06",
+          "dateInfoTimeFormat": "05:19:54",
+          "height": 222,
+          "confirmations": 29,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": 0,
+      "changeIndex": 3,
+      "balance": 163333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+        "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": 222,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1530847194,
+          "dateInfoDayFormat": "2018-07-06",
+          "dateInfoTimeFormat": "05:19:54",
+          "height": 222,
+          "confirmations": 29,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": 0,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+        "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in confirmed -> in out conf, in unconf at change",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead202",
+        "height": 202
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": 222,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        },
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            2
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+          "targets": [
+            {
+              "address": "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "140d3a91d52a3a3372a017a8164ae97eeaec9e55aa89303ae0472172801ec5ca",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 163333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1530847194,
+          "dateInfoDayFormat": "2018-07-06",
+          "dateInfoTimeFormat": "05:19:54",
+          "height": 222,
+          "confirmations": 29,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": 0,
+      "changeIndex": 3,
+      "balance": 163333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+        "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 202,
+          "resultError": false,
+          "result": "000000000000dead202"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": 222,
+              "timestamp": 1530847194,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006a473044022060b30ae368bdf04ecf4a8b564897e757e6d8f7eec6b0e0c86dd01557daf07cb402202c2e129304da6732f0e0fa62b597a8e149c87f8dcedda1c85fd8ea1142936da40121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a914a1dbf6b949617db8512a7ca8ab183e845c33b8d488ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": 222,
+              "timestamp": 1530847194,
+              "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            },
+            {
+              "hex": "0200000001cac51e80722147e03a3089aa559eecea7ee94a16a817a072333a2ad5913a0d14010000006b483045022100ad687861f76e11a61367e3e3e227562b7ecae55c20447fdfccf127f55332550b022013a8ae5debba7ccb51f42bd432e280b275d0b4ddcb57d0d3ad75a112c7c7a331012102432d7a92e8e9c50fe3d91cc2f8fe77a9d065d665b1c8e0b73b7c1a50e59f7675feffffff0280a4bf07000000001976a914a8d99b761abbd7716f746b42a43f8004d67b654088ac4ad9fa51000000001976a91420f6f8776e252e9cbdc7552b0855565c298da16188ace19d1400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+              "inputAddresses": [
+                "mo9bPNoQEYjj1345mDKrUC3aHwEGkyFJyc"
+              ],
+              "outputAddresses": [
+                "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+                "miXFn1TqTHpR2HBj5t4sV5JzFxoaK4HXcX"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ],
+          "start": 250,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "in out conf, in unconf at change, preserves itself",
+    "start": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": 222,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        },
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            2
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+          "targets": [
+            {
+              "address": "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "140d3a91d52a3a3372a017a8164ae97eeaec9e55aa89303ae0472172801ec5ca",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 163333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1530847194,
+          "dateInfoDayFormat": "2018-07-06",
+          "dateInfoTimeFormat": "05:19:54",
+          "height": 222,
+          "confirmations": 29,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": 0,
+      "changeIndex": 3,
+      "balance": 163333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+        "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": 222,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        },
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            2
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+          "targets": [
+            {
+              "address": "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "140d3a91d52a3a3372a017a8164ae97eeaec9e55aa89303ae0472172801ec5ca",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 163333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1530847194,
+          "dateInfoDayFormat": "2018-07-06",
+          "dateInfoTimeFormat": "05:19:54",
+          "height": 222,
+          "confirmations": 29,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": 0,
+      "changeIndex": 3,
+      "balance": 163333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+        "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": [
+            {
+              "hex": "0200000001cac51e80722147e03a3089aa559eecea7ee94a16a817a072333a2ad5913a0d14010000006b483045022100ad687861f76e11a61367e3e3e227562b7ecae55c20447fdfccf127f55332550b022013a8ae5debba7ccb51f42bd432e280b275d0b4ddcb57d0d3ad75a112c7c7a331012102432d7a92e8e9c50fe3d91cc2f8fe77a9d065d665b1c8e0b73b7c1a50e59f7675feffffff0280a4bf07000000001976a914a8d99b761abbd7716f746b42a43f8004d67b654088ac4ad9fa51000000001976a91420f6f8776e252e9cbdc7552b0855565c298da16188ace19d1400",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "befed550371854379ae4e9675e798082d1023cd380a8f1257a9f0b07b0bf3425",
+              "inputAddresses": [
+                "mo9bPNoQEYjj1345mDKrUC3aHwEGkyFJyc"
+              ],
+              "outputAddresses": [
+                "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+                "miXFn1TqTHpR2HBj5t4sV5JzFxoaK4HXcX"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One confirmed tx, zcash testnet",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 300000000,
+          "transactionHash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 381,
+          "tsize": 381,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+          "targets": [
+            {
+              "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+              "value": 300000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 300000000,
+          "myOutputs": {
+            "0": {
+              "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+              "value": 300000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "4e8e8c5a5524cb8b20d05aefd5b1fd004d6c8c584e3e314876f13edb5ba0eead",
+              "index": 0
+            },
+            {
+              "id": "7afab9216fee6763ffbd6a412d46d68c480220af093c9becee6f79d41b954b13",
+              "index": 0
+            }
+          ],
+          "tsize": 381,
+          "vsize": 381,
+          "balance": 300000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+          "received": 300000000
+        }
+      ],
+      "unusedAddresses": [
+        "tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+        "tmB5LZ6oSKTaCoKYVy7PDBP4L7WAfzxu882",
+        "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 300000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "tmFJ9NfQpnHsjEQqH3j74nEEmPHBCkHcizj",
+        "tmDixyt4GZwsCxhRHjucexcmXgFK2U7zA2P",
+        "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 7461,
+      "scriptHash": 7354,
+      "bech32": null,
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+            "tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+            "tmB5LZ6oSKTaCoKYVy7PDBP4L7WAfzxu882"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "030000807082c40302adeea05bdb3ef17648313e4e588c6c4d00fdb1d5ef5ad0208bcb24555a8c8e4e000000006a473044022064e1e5f957308fcc91f7b174113c8e3cb8060b1404ae823ab3f77f313d5b557b02204b2afcde9ef8b61f5e85192c38fb82307d077ec91d2c8249aa69e19967df8c0c01210201d494a45f36f545443bafd1a9050b02f448dd236bb4ce2602f83978980b98f2feffffff134b951bd4796feeec9b3c09af2002488cd6462d416abdff6367ee6f21b9fa7a000000006a47304402207f63a484ee75900ce2b0e2a5f0d52f2cfb5d1475588576f645c20ecf5e04659a02205c9b614ca846b0cb9ff4a72ca8482c9aed542282b9ee8eaa70a5f472408f3f04012103e974b89ace172f24bb25f8137d19c4205c5cf6bb6505454230ea172f54152d08feffffff0200a3e111000000001976a914a579388225827d9f2fe9014add644487808c695d88ac40191300000000001976a91474374446b18916decd3292384ea73006ebd268ba88aca7fc0300c6fc030000",
+              "zcash": true,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+              "inputAddresses": [
+                "tmKBPqa8qqKA7vrGq1AaXHSAr9vqa3GczzK",
+                "tmR2f5ZtUqC7GzECY7LTxZjNm1uf9Mu1YEJ"
+              ],
+              "outputAddresses": [
+                "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+                "tmLJqvRRHXgQTCPww82mdi6oNXGuC5zj2dw"
+              ],
+              "vsize": 381
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmFJ9NfQpnHsjEQqH3j74nEEmPHBCkHcizj",
+            "tmDixyt4GZwsCxhRHjucexcmXgFK2U7zA2P",
+            "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "2 confirmed incoming tx, 1 zcash shielded",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 300000000,
+          "transactionHash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 381,
+          "tsize": 381,
+          "own": false
+        },
+        {
+          "index": 0,
+          "value": 10000000000,
+          "transactionHash": "54030da65e71760b7ce18755955afd701b33c1e432db33b43b54c53d39ee52f4",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            3
+          ],
+          "vsize": 1951,
+          "tsize": 1951,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+          "targets": [
+            {
+              "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+              "value": 300000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 300000000,
+          "myOutputs": {
+            "0": {
+              "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+              "value": 300000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "4e8e8c5a5524cb8b20d05aefd5b1fd004d6c8c584e3e314876f13edb5ba0eead",
+              "index": 0
+            },
+            {
+              "id": "7afab9216fee6763ffbd6a412d46d68c480220af093c9becee6f79d41b954b13",
+              "index": 0
+            }
+          ],
+          "tsize": 381,
+          "vsize": 381,
+          "balance": 10300000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "54030da65e71760b7ce18755955afd701b33c1e432db33b43b54c53d39ee52f4",
+          "targets": [
+            {
+              "address": "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9",
+              "value": 10000000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 10000000000,
+          "myOutputs": {
+            "0": {
+              "address": "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9",
+              "value": 10000000000,
+              "i": 0
+            }
+          },
+          "inputs": [],
+          "tsize": 1951,
+          "vsize": 1951,
+          "balance": 10000000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+          "received": 300000000
+        },
+        {
+          "address": "tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+          "received": 0
+        },
+        {
+          "address": "tmB5LZ6oSKTaCoKYVy7PDBP4L7WAfzxu882",
+          "received": 0
+        },
+        {
+          "address": "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9",
+          "received": 10000000000
+        }
+      ],
+      "unusedAddresses": [
+        "tmHRQfcNVCZnjY8g6X7Yp6Tcpx8M5gy4Joj",
+        "tmPixaSEroFtgMRTiNcQj9uPdxSMWA3dz2j",
+        "tmGjR8NA2Yd3z2XzXND7hUFZcUsiYJjLJBF"
+      ],
+      "lastConfirmedMain": 3,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 10300000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "tmFJ9NfQpnHsjEQqH3j74nEEmPHBCkHcizj",
+        "tmDixyt4GZwsCxhRHjucexcmXgFK2U7zA2P",
+        "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 7461,
+      "scriptHash": 7354,
+      "bech32": null,
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+            "tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+            "tmB5LZ6oSKTaCoKYVy7PDBP4L7WAfzxu882"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "030000807082c40302adeea05bdb3ef17648313e4e588c6c4d00fdb1d5ef5ad0208bcb24555a8c8e4e000000006a473044022064e1e5f957308fcc91f7b174113c8e3cb8060b1404ae823ab3f77f313d5b557b02204b2afcde9ef8b61f5e85192c38fb82307d077ec91d2c8249aa69e19967df8c0c01210201d494a45f36f545443bafd1a9050b02f448dd236bb4ce2602f83978980b98f2feffffff134b951bd4796feeec9b3c09af2002488cd6462d416abdff6367ee6f21b9fa7a000000006a47304402207f63a484ee75900ce2b0e2a5f0d52f2cfb5d1475588576f645c20ecf5e04659a02205c9b614ca846b0cb9ff4a72ca8482c9aed542282b9ee8eaa70a5f472408f3f04012103e974b89ace172f24bb25f8137d19c4205c5cf6bb6505454230ea172f54152d08feffffff0200a3e111000000001976a914a579388225827d9f2fe9014add644487808c695d88ac40191300000000001976a91474374446b18916decd3292384ea73006ebd268ba88aca7fc0300c6fc030000",
+              "zcash": true,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+              "inputAddresses": [
+                "tmKBPqa8qqKA7vrGq1AaXHSAr9vqa3GczzK",
+                "tmR2f5ZtUqC7GzECY7LTxZjNm1uf9Mu1YEJ"
+              ],
+              "outputAddresses": [
+                "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+                "tmLJqvRRHXgQTCPww82mdi6oNXGuC5zj2dw"
+              ],
+              "vsize": 381
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "030000807082c403000100e40b54020000001976a9145a9452b8db22e7fb606adafc731f5d4b482f9e8d88ac0000000087fd0300010000000000000000100b0c5402000000469e494b04622324b7ebc44270325f2404d162d111b0a8a4d828a62c7f59e774005f59b13fdee9b9eea155258b81c6dd5e37c29a5ae058c6684678645b64c9cd5c218360670823fd7121225ffd3f1247fa20e04e46191dcb27c2bc4c61419fc0085dbc00c645aa25ab3bfd84a3f0cb298c22b812bf270783223c8afb63fd46da52c67af1a0123c6a54a6f0a609b8bf44e4873772c679b8a34af80a5ffd1a550d37304a7840744aa186d7a45b444f104ea43e113c7c83de73e0eafde03dfc9a78894a91486d1de0daa27abc9597f18905f0de74f74de56c60043106960a537c27f845bb2099edd1715aac6ef42e81099bdeced773e95e2c6a8030bfa118c84b143d62b4b4ca4ebcf72a57dfa0059675ffdbecf896a5790bacb862013adc8861330313ea10ca44d8e8b0c2fada7e30b80d1d2328d0093401010e6838c1e8e081e46802090510f474f48d6d9a4abce6b019ea43d77a47dab648d4170c574baed39d56740a070b0218529767f34da26ea8d9cdf70d8b547243e02a7c3b79b6346a2e4c515ac5e777f37bc3849d2bab94bb32867085f1ea0ee356a2f598bcfe05aae102ad21020af585451668f8a998efd61c6f7e1933185f0ff75314e45ec29ada89b6043590020b84a5e71fd139dae1d4a72b1053075d0936454c90850ceea7dec96c1e191bc9022aef35e223efc62ea78922baaf9481510b571559d05f7d1bfd56131c9a31fb9a02270678e13651b4e8e4b5ef7de36c78d3815d369f3d4565dc5a2d465ada3fb8c6031d7b251e1adf1bca49b106f73dd7111157f2cdf2dfc45580b43bb4a780ca67d630ed94c682694bf80a7180baec0dd4f0bff9b8c4910c7c49026979bf2cd1a91574fda2c56d9ad3d7360ecd1148f94d3ce3ca54e8cb0a67bb0c0c14a5b1c0df5a339bac06e35f0d9ce8ffed177c1ad7f63859b7db89f120fad24c83d143e448b6d9bf003917d9a4df42e7d24e73a003de38f507c4476f65db2c9c4291cedb0730e1591de57260b67315a3ea1b6ff86977f12f9b13920fc0fd92df09e66aba84919206b84cbf7116ade8d6ff8b3486dc723956f047dc46dff0b2d1560e3f79f6df26c2f3a058f6b18348577846f13c4e9ca473515e53efbe0a1dcafa7e67897a7e29e39bcbb1cf1b3f8c31d073a2cee1e0d43d0484c36db8cdb3c197614305e63db2b70dae39a6d957754d349afb19de6cc1d0a8bb27ba290a0f96c8733755aa990c005a9bd0fac06426261497454c820c19485e9dbef5366a905f37dd434f34caebf8102c8765b021eee971978b77c75c71fe235a2dcd62bba75a55fd825f7ebdd71a08e7943c8c92a86b9103015cde067818e0fe9c4f260c6a8d33fae9ac9bdbbc6a1e42a0124d88146b82e9f7cb4ac230c4086b54144268187ea4943941de31c2a4fff155ef2ac949575a9da442ca05c06b85e808b71df750451e2efe51f5e41dae6a7b991a9bd29b1ff857089acf34491bab943d2f360c6c47f580cb0e379ba64e06cff172d3c559fdb462f3d3bc7ceaa2bab645be2ae32b0d885f4e36a43d3023f2267d56ac0839d7568da80ec04aba1e58a82d99d2970ee4fdb43734644c48f2a64ab42ceb649e35d5852649d381f7c7f3cda7f967bab16731a3a4df7ac57f91dc701f8676f6d5157aa93c9490d0327dcf30c9ae59eeb0a2b13e7b94adc625c29cc34e2633bc9f70dd73be4617bdbcd145683ca6ea206c837bee51aa01f89fbd1d447b939f510baf12d5ee14e8b2ac2595e3cf7b30ecd14c08abe8009d1fd0f360e9e4cece3f4be5ee86d1e41ba3397db56d39167f9d30ac58c7419129bcd639de453bc39706f1a2a92ab2ab0864de5007a6d57ebdeb04023cc44d3e4c07417a9957228e9dd1ae095d81e66172adf1cd27f2fde3ebf4cc4be3e9bb8692cad55ab106c78f9e0ec0c82e01e1abf34380c62a7929739464dccca59998d91700defcd4e27cb862d35ce550c0300e6178b86efe73d0c7f40c9f1d6b4138c3e26228b2f645ceaa052536001d48ad3b4a897d54282dda4f81999f0f026ee5b62c636cf14a36bc0be5404d5a5df0f7c1cdc4ce76fee178350229c87f5f63b316a90b53ca6fe8b40069b5ca4a6bda4ac768f2537e0934535f164b28e20fa5d1a998efa22c3ae5e2873df054b6e4ce8380e11ccb2183aa2c0652704aae659a4109fd6a3661d16d7e6183def916b6bada2290f1340f457981df0dd99e83f7dd638281756562e09a8a3ba59d4a1e3e6b368559d27d7ad309ab749645fc5e2da079642022463e6fe75d139e890aaa9beea944069767599af8e9a27a69e12878e9127ca97dcab9c64fa14e61e25ff7990e6adcfae1fb362ac427924339e7cf22aad58f890eee7e9e1ff09731d95997fb2015a04e4a0958da63c77aabefcac16eec117f149c94cc331d8c1c845f394a6b6c2994b849a4e906e95793a4d0736dc8e324cde6f1deb183195efaf0e85aa1354e7fd5007a70b73036db6f7480580ca88004eb542b23df1a9f8ed2eed65f0ad438f5c78b534c5f976edc0c36d3b8566b78f776ac5d5d7445fcf8de3194035e1ae4cffd24fb5274d044d53d1259decbbce715336bc252a7b79b60a44c87df023d921bbfd9c6353110f18cec0dd48b37d935d97ff78cbf8af8247e44b6c9eda86617a58ee3e54404",
+              "zcash": true,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "54030da65e71760b7ce18755955afd701b33c1e432db33b43b54c53d39ee52f4",
+              "inputAddresses": [],
+              "outputAddresses": [
+                "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+              ],
+              "vsize": 1951
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmHRQfcNVCZnjY8g6X7Yp6Tcpx8M5gy4Joj",
+            "tmPixaSEroFtgMRTiNcQj9uPdxSMWA3dz2j",
+            "tmGjR8NA2Yd3z2XzXND7hUFZcUsiYJjLJBF"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmFJ9NfQpnHsjEQqH3j74nEEmPHBCkHcizj",
+            "tmDixyt4GZwsCxhRHjucexcmXgFK2U7zA2P",
+            "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "zcash 3 conf, 1 unshielded in 1 shielded in 1 out shield",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 300000000,
+          "transactionHash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 381,
+          "tsize": 381,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "4a882a91e38bc46c54ae6b078dc7f778d613fd2aeccd4274f419e3586b20574b",
+          "targets": [
+            {
+              "address": "tmGoFQfi3XHMq7TihKADcMTMMeX54C7tdqH",
+              "value": 99990000,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -10000000000,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "54030da65e71760b7ce18755955afd701b33c1e432db33b43b54c53d39ee52f4",
+              "index": 0
+            }
+          ],
+          "tsize": 2099,
+          "vsize": 2099,
+          "balance": 300000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+          "targets": [
+            {
+              "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+              "value": 300000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 300000000,
+          "myOutputs": {
+            "0": {
+              "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+              "value": 300000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "4e8e8c5a5524cb8b20d05aefd5b1fd004d6c8c584e3e314876f13edb5ba0eead",
+              "index": 0
+            },
+            {
+              "id": "7afab9216fee6763ffbd6a412d46d68c480220af093c9becee6f79d41b954b13",
+              "index": 0
+            }
+          ],
+          "tsize": 381,
+          "vsize": 381,
+          "balance": 10300000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "54030da65e71760b7ce18755955afd701b33c1e432db33b43b54c53d39ee52f4",
+          "targets": [
+            {
+              "address": "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9",
+              "value": 10000000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 10000000000,
+          "myOutputs": {
+            "0": {
+              "address": "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9",
+              "value": 10000000000,
+              "i": 0
+            }
+          },
+          "inputs": [],
+          "tsize": 1951,
+          "vsize": 1951,
+          "balance": 10000000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+          "received": 300000000
+        },
+        {
+          "address": "tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+          "received": 0
+        },
+        {
+          "address": "tmB5LZ6oSKTaCoKYVy7PDBP4L7WAfzxu882",
+          "received": 0
+        },
+        {
+          "address": "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9",
+          "received": 10000000000
+        }
+      ],
+      "unusedAddresses": [
+        "tmHRQfcNVCZnjY8g6X7Yp6Tcpx8M5gy4Joj",
+        "tmPixaSEroFtgMRTiNcQj9uPdxSMWA3dz2j",
+        "tmGjR8NA2Yd3z2XzXND7hUFZcUsiYJjLJBF"
+      ],
+      "lastConfirmedMain": 3,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 300000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {
+        "4a882a91e38bc46c54ae6b078dc7f778d613fd2aeccd4274f419e3586b20574b:0": "tmGoFQfi3XHMq7TihKADcMTMMeX54C7tdqH"
+      },
+      "changeAddresses": [
+        "tmFJ9NfQpnHsjEQqH3j74nEEmPHBCkHcizj",
+        "tmDixyt4GZwsCxhRHjucexcmXgFK2U7zA2P",
+        "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 7461,
+      "scriptHash": 7354,
+      "bech32": null,
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+            "tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+            "tmB5LZ6oSKTaCoKYVy7PDBP4L7WAfzxu882"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "030000807082c40302adeea05bdb3ef17648313e4e588c6c4d00fdb1d5ef5ad0208bcb24555a8c8e4e000000006a473044022064e1e5f957308fcc91f7b174113c8e3cb8060b1404ae823ab3f77f313d5b557b02204b2afcde9ef8b61f5e85192c38fb82307d077ec91d2c8249aa69e19967df8c0c01210201d494a45f36f545443bafd1a9050b02f448dd236bb4ce2602f83978980b98f2feffffff134b951bd4796feeec9b3c09af2002488cd6462d416abdff6367ee6f21b9fa7a000000006a47304402207f63a484ee75900ce2b0e2a5f0d52f2cfb5d1475588576f645c20ecf5e04659a02205c9b614ca846b0cb9ff4a72ca8482c9aed542282b9ee8eaa70a5f472408f3f04012103e974b89ace172f24bb25f8137d19c4205c5cf6bb6505454230ea172f54152d08feffffff0200a3e111000000001976a914a579388225827d9f2fe9014add644487808c695d88ac40191300000000001976a91474374446b18916decd3292384ea73006ebd268ba88aca7fc0300c6fc030000",
+              "zcash": true,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368",
+              "inputAddresses": [
+                "tmKBPqa8qqKA7vrGq1AaXHSAr9vqa3GczzK",
+                "tmR2f5ZtUqC7GzECY7LTxZjNm1uf9Mu1YEJ"
+              ],
+              "outputAddresses": [
+                "tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu",
+                "tmLJqvRRHXgQTCPww82mdi6oNXGuC5zj2dw"
+              ],
+              "vsize": 381
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "030000807082c403000100e40b54020000001976a9145a9452b8db22e7fb606adafc731f5d4b482f9e8d88ac0000000087fd0300010000000000000000100b0c5402000000469e494b04622324b7ebc44270325f2404d162d111b0a8a4d828a62c7f59e774005f59b13fdee9b9eea155258b81c6dd5e37c29a5ae058c6684678645b64c9cd5c218360670823fd7121225ffd3f1247fa20e04e46191dcb27c2bc4c61419fc0085dbc00c645aa25ab3bfd84a3f0cb298c22b812bf270783223c8afb63fd46da52c67af1a0123c6a54a6f0a609b8bf44e4873772c679b8a34af80a5ffd1a550d37304a7840744aa186d7a45b444f104ea43e113c7c83de73e0eafde03dfc9a78894a91486d1de0daa27abc9597f18905f0de74f74de56c60043106960a537c27f845bb2099edd1715aac6ef42e81099bdeced773e95e2c6a8030bfa118c84b143d62b4b4ca4ebcf72a57dfa0059675ffdbecf896a5790bacb862013adc8861330313ea10ca44d8e8b0c2fada7e30b80d1d2328d0093401010e6838c1e8e081e46802090510f474f48d6d9a4abce6b019ea43d77a47dab648d4170c574baed39d56740a070b0218529767f34da26ea8d9cdf70d8b547243e02a7c3b79b6346a2e4c515ac5e777f37bc3849d2bab94bb32867085f1ea0ee356a2f598bcfe05aae102ad21020af585451668f8a998efd61c6f7e1933185f0ff75314e45ec29ada89b6043590020b84a5e71fd139dae1d4a72b1053075d0936454c90850ceea7dec96c1e191bc9022aef35e223efc62ea78922baaf9481510b571559d05f7d1bfd56131c9a31fb9a02270678e13651b4e8e4b5ef7de36c78d3815d369f3d4565dc5a2d465ada3fb8c6031d7b251e1adf1bca49b106f73dd7111157f2cdf2dfc45580b43bb4a780ca67d630ed94c682694bf80a7180baec0dd4f0bff9b8c4910c7c49026979bf2cd1a91574fda2c56d9ad3d7360ecd1148f94d3ce3ca54e8cb0a67bb0c0c14a5b1c0df5a339bac06e35f0d9ce8ffed177c1ad7f63859b7db89f120fad24c83d143e448b6d9bf003917d9a4df42e7d24e73a003de38f507c4476f65db2c9c4291cedb0730e1591de57260b67315a3ea1b6ff86977f12f9b13920fc0fd92df09e66aba84919206b84cbf7116ade8d6ff8b3486dc723956f047dc46dff0b2d1560e3f79f6df26c2f3a058f6b18348577846f13c4e9ca473515e53efbe0a1dcafa7e67897a7e29e39bcbb1cf1b3f8c31d073a2cee1e0d43d0484c36db8cdb3c197614305e63db2b70dae39a6d957754d349afb19de6cc1d0a8bb27ba290a0f96c8733755aa990c005a9bd0fac06426261497454c820c19485e9dbef5366a905f37dd434f34caebf8102c8765b021eee971978b77c75c71fe235a2dcd62bba75a55fd825f7ebdd71a08e7943c8c92a86b9103015cde067818e0fe9c4f260c6a8d33fae9ac9bdbbc6a1e42a0124d88146b82e9f7cb4ac230c4086b54144268187ea4943941de31c2a4fff155ef2ac949575a9da442ca05c06b85e808b71df750451e2efe51f5e41dae6a7b991a9bd29b1ff857089acf34491bab943d2f360c6c47f580cb0e379ba64e06cff172d3c559fdb462f3d3bc7ceaa2bab645be2ae32b0d885f4e36a43d3023f2267d56ac0839d7568da80ec04aba1e58a82d99d2970ee4fdb43734644c48f2a64ab42ceb649e35d5852649d381f7c7f3cda7f967bab16731a3a4df7ac57f91dc701f8676f6d5157aa93c9490d0327dcf30c9ae59eeb0a2b13e7b94adc625c29cc34e2633bc9f70dd73be4617bdbcd145683ca6ea206c837bee51aa01f89fbd1d447b939f510baf12d5ee14e8b2ac2595e3cf7b30ecd14c08abe8009d1fd0f360e9e4cece3f4be5ee86d1e41ba3397db56d39167f9d30ac58c7419129bcd639de453bc39706f1a2a92ab2ab0864de5007a6d57ebdeb04023cc44d3e4c07417a9957228e9dd1ae095d81e66172adf1cd27f2fde3ebf4cc4be3e9bb8692cad55ab106c78f9e0ec0c82e01e1abf34380c62a7929739464dccca59998d91700defcd4e27cb862d35ce550c0300e6178b86efe73d0c7f40c9f1d6b4138c3e26228b2f645ceaa052536001d48ad3b4a897d54282dda4f81999f0f026ee5b62c636cf14a36bc0be5404d5a5df0f7c1cdc4ce76fee178350229c87f5f63b316a90b53ca6fe8b40069b5ca4a6bda4ac768f2537e0934535f164b28e20fa5d1a998efa22c3ae5e2873df054b6e4ce8380e11ccb2183aa2c0652704aae659a4109fd6a3661d16d7e6183def916b6bada2290f1340f457981df0dd99e83f7dd638281756562e09a8a3ba59d4a1e3e6b368559d27d7ad309ab749645fc5e2da079642022463e6fe75d139e890aaa9beea944069767599af8e9a27a69e12878e9127ca97dcab9c64fa14e61e25ff7990e6adcfae1fb362ac427924339e7cf22aad58f890eee7e9e1ff09731d95997fb2015a04e4a0958da63c77aabefcac16eec117f149c94cc331d8c1c845f394a6b6c2994b849a4e906e95793a4d0736dc8e324cde6f1deb183195efaf0e85aa1354e7fd5007a70b73036db6f7480580ca88004eb542b23df1a9f8ed2eed65f0ad438f5c78b534c5f976edc0c36d3b8566b78f776ac5d5d7445fcf8de3194035e1ae4cffd24fb5274d044d53d1259decbbce715336bc252a7b79b60a44c87df023d921bbfd9c6353110f18cec0dd48b37d935d97ff78cbf8af8247e44b6c9eda86617a58ee3e54404",
+              "zcash": true,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "54030da65e71760b7ce18755955afd701b33c1e432db33b43b54c53d39ee52f4",
+              "inputAddresses": [],
+              "outputAddresses": [
+                "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+              ],
+              "vsize": 1951
+            },
+            {
+              "hex": "030000807082c40301f452ee393dc5543bb433db32e4c1331b70fd5a955587e17c0b76715ea60d0354000000006b483045022100e20727eda19932196e8227a448dbf993e203048067b2543c649b2c58000f981602204ed561934440548d37774cd856e8a77e02a1b2674824bd749944eaa63b54c4050121029ad0b9519779c540b34fa8d11d24d14a5475546bfa28c7de50573d22a503ce21ffffffff01f0b9f505000000001976a9144db60436fe5120ecd20b49e9d84ed93aa105f23688ac00000000b80d0400010003164e02000000000000000000000018723a1053480a7ddb7593d102c935d1f6378edd67992f6df5f990b98a63c69b1cb5ee8ed4af1a5ebf511b32d14e46d250091df94e794c64325b5508ebbc992e3adb8f853dfbda2eed145533bd269256f6ce7236ed18f3f0cf74b5506c104f9dddfd13fea38d5b7668e9f7b9698627de3f97d79d41fef21075227fc23c7de9530f70b03a223f434b9256af614df07106f7f450fe258f0dd66302eebce559b5cdf5a5275de24787e85df21bf6a13177e6ffcd936458e376ccaa4a979d54983e5677e34da0da1979e513893d54deb38d0f04aca64b19b2852d0cd849eb357b40f5e0d49a2b048d8b40632ec484840096b5dbc18c2ffe1e3defa49a6dc0534c2f537d7c6e35ef40fc94300a08f1c91de9451af3d0de1611df6c4ba9cb730a08af78032e828e1ff08935a2e33d42d3517879ea4b6abf27de575655429a32e9075d33c40212333e39a3b9e1708696691d495cd9d87e512a3ab49194ae5068df78060b91990a081fbd8dd83bdebf774197cbfc06b38d8b75d0b7efbb93fa7986cd6670fbae82a8f3ea8e0c9f039c0a31683ddecf556de9b1fb57666133a2dbd222c6a5a7abfd0327ac8fb03b1a598ebdcc8880e42af2c4495c5644c97fd29381e60a4ad209f8c20303d49776e40622640bda793fd852838bff5139f61ae6c9150271a7d2999b24460222c118a35eeb6269f2e83a7b1998dec50eef1fd85baadfa2d41aba16df7ae44a02209b105011329c1151fd39fe6a21c97806c6aace1cd2b2410dbd63d77f6889a2021c5046401db3eb053a823f8543be50306d652f5ada139c2ed900b2b02680c4f327a63e965cc768e3e8b00e56b0c5b5001b56c415576aa49358139dd3dc2973b85b3cbbefb4cecf9cb0212357aa6075d161fd8431e4bd31643a797065feb81585f0edde5b9fb976860df2a4723276cebed06171aa47266bdb9edcd9c6d3fdd47252747120a205f4f5f2ba7b88ecc405664aaa467eedfc048978dbd7a5087a8f65a144ee25810186d2ce677aab1fa4432cd733152d939091e042b0baa80d9cc61465a88126933f8ae21db8d6483fc6bc3bebb70e0fd8ac7c0440e65bd9956cc3173adef72eab3685055ed94c034436a0c0d40b723e5d36cde6c45ded2df7c3f6972c1b34048d45331f32c6fef506184860dd97a403eac14d93029020d9b78c8dc7a1827351026ed5de4eea8500383756dfabda51b5c3a7100f9596c13710dbfda2bbc1d5da6e550135b304ab81060fbc045f651000fda61175619e1e00e81de90e0d51891f88e9b4eaf17e9aa39927bfc114edbb21d1d2163dfcdf8dcce517a4c9500f32b9953588e91f5b9d7934172e469062a8d70e7a8189c6b4846a0e257d7a74c3fa92a9f5cf4e48efa755b1ed00af6618470864a13fea5bd841f3e9c372d59082d9a0d45503044fb677a9082a09daa631888d5e950403b133c393c0499d550a1a440f19b19f3bb83a3637541a57369b405d7163f73fbc1db583b7e9b2746d9384c7eead74b691951fde323c493336fab5ddfcc58b76cd1be509fe3cb6a62d876e6a1955000c4b2f50ffe59fea95a53fd239ec554f8a556b45b7d92233550eb32b8fbc6dce61f030254c99275cfc7905725a26c6843c33455061b827c5d22c45da10053f943d7c7551386961dc23e84db3d73a9252cf7dfe35156e88fee19a680dcffb064229a71a42b376dbdc420d9f9a9e543fe76c137d5dc927e2c0364140a9c0d702d5a800156cc1bdc69fcb596de08fbb9ab2b1e89e51414650b8f471a9bc030473cd25b62715e7dfbd9ad944afc0494e563593c6122ee25e3ce1809fac0d0f01510d4203286b46672866948554c667870a914187c3469fc8911c5d3bc8fc4228c4450c536ebc87b97ce725ce9705e6e76455a006f6bf632e5ba697e191d78771ded09571f42df53b34964013faeaec380fabd917da8fa2bfd82a1cbd33924bca5238f57c1ffab9fd1947e8d88a05d5df224377241fe80fc44cff78b88890c65bbc739ec150837ab0569a9eccd60ac8f08e51da6c42fd45fdb5574f96567723f5bb6a4a16749671f0bb97eda366ed5b24e1e8b14f3bb9f6bd7c484e8cc97ca1bd67df113574fb53c83eccc29b09cb599ff1408f0810121d2f10e92e56e7ce86f424c17514538962bc7b5eee61412a26f0f3b814d429cd85463a24588bf1a344aa9d10ad32ab57ca846caa057b19ea731f0cadf84e4db08037f963f34e0d1ab03c1e7584fd920307460c1c1dacb42870734cc439cf8c0756dd783e97a0db15192ef042405c646ca30c83c5b4fb84141050ac46c32c3d40642d9f4ba95f85808ce656bd404a0fcd1e4d93ad226feee2098cd56e3f5e2fde4aa1acf402b2a38ddbf2ba0b877bc0b45bd7ad4b66b1070c4c8116f9265428622b6d00b51a31c8e95a29ff751c9e92be24864fd658dd2ed9eb045e6c9a92ed4e685ac755bf1048e4cf690d7f864938b41f9e1312212f51d43a3a7f09df7facac8d7b7248022ebe4cf8e99580391acff3c7cc3ccb3042dc9f3180bef8f4fe2730f878da60960ab2ce4385ccad23ff23bb89d31cdb211ba065a8e52cd323f710d9d546d73889bde75ba9e76fc37eae6b37d5926afdd76c6ba09c0f110926f0d65174384d707525110af33000c2cd9a888519d4cf4e9cdee504",
+              "zcash": true,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "4a882a91e38bc46c54ae6b078dc7f778d613fd2aeccd4274f419e3586b20574b",
+              "inputAddresses": [
+                "tmHyHq7Ec5oPXBDdyfDHAuqWphwEXxK5yZ9"
+              ],
+              "outputAddresses": [
+                "tmGoFQfi3XHMq7TihKADcMTMMeX54C7tdqH"
+              ],
+              "vsize": 2099
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmHRQfcNVCZnjY8g6X7Yp6Tcpx8M5gy4Joj",
+            "tmPixaSEroFtgMRTiNcQj9uPdxSMWA3dz2j",
+            "tmGjR8NA2Yd3z2XzXND7hUFZcUsiYJjLJBF"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "tmFJ9NfQpnHsjEQqH3j74nEEmPHBCkHcizj",
+            "tmDixyt4GZwsCxhRHjucexcmXgFK2U7zA2P",
+            "tmR79Y1xfWJsFFusjpehZnC5QtWz8fdCtZJ"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One incoming confirmed, with OP_RETURN",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 49870130,
+          "transactionHash": "45d093731ae556580da86dfc0924fdbb12fb60386b7c6e91699316a9fe49e562",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 166,
+          "tsize": 166,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "45d093731ae556580da86dfc0924fdbb12fb60386b7c6e91699316a9fe49e562",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 49870130,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 49870130,
+          "myOutputs": {
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 49870130,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "4ee68db5da52df37330657a07154582d739b3d4acce90a964b6452a39a5fef26",
+              "index": 1
+            }
+          ],
+          "tsize": 166,
+          "vsize": 166,
+          "balance": 49870130
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 49870130
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 49870130,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "010000000126ef5f9aa352644b960ae9cc4a3d9b732d585471a057063337df52dab58de64e01000000171600145183a8cd6827ed3249d2c667df4f5ce94ca88918ffffffff0300000000000000000f6a0d626974636f696e207375636b7332f5f802000000001976a914a579388225827d9f2fe9014add644487808c695d88ac80f0fa02000000001976a91454bd837a7dc2ea7f2b52ca0e1dcb07808e8acba988ac00000000",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "45d093731ae556580da86dfc0924fdbb12fb60386b7c6e91699316a9fe49e562",
+              "inputAddresses": [
+                "2N4BrUeq26v13gGDRNNWd6Q3L7ADp75Lqzp"
+              ],
+              "outputAddresses": [
+                null,
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "moF25oWYTeN6V5USsvHFEkZp8CR2KimVdu"
+              ],
+              "vsize": 166
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "One incoming one outgoing confirmed, both with OP_RETURN",
+    "note": "This is also an edge case for testing address behind gap; the receiving address on the second TX is mine, but behind gap, so should not register as mine",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "545e31eac493e1e7afe8656504695ebcd8e56dda24dc5e8d6e9b8d7074b94c1b",
+          "targets": [
+            {
+              "address": "OP_RETURN (kokos!)",
+              "value": 0,
+              "i": 0
+            },
+            {
+              "address": "mpaXJ6yWNAeJuEVuFReoTfMGn4VyPSiEbK",
+              "value": 49867600,
+              "i": 1
+            }
+          ],
+          "type": "sent",
+          "value": -49870130,
+          "myOutputs": {},
+          "inputs": [
+            {
+              "id": "45d093731ae556580da86dfc0924fdbb12fb60386b7c6e91699316a9fe49e562",
+              "index": 1
+            }
+          ],
+          "tsize": 208,
+          "vsize": 208,
+          "balance": 0
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "45d093731ae556580da86dfc0924fdbb12fb60386b7c6e91699316a9fe49e562",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 49870130,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 49870130,
+          "myOutputs": {
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 49870130,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "4ee68db5da52df37330657a07154582d739b3d4acce90a964b6452a39a5fef26",
+              "index": 1
+            }
+          ],
+          "tsize": 166,
+          "vsize": 166,
+          "balance": 49870130
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 49870130
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 0,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {
+        "545e31eac493e1e7afe8656504695ebcd8e56dda24dc5e8d6e9b8d7074b94c1b:0": "OP_RETURN (kokos!)",
+        "545e31eac493e1e7afe8656504695ebcd8e56dda24dc5e8d6e9b8d7074b94c1b:1": "mpaXJ6yWNAeJuEVuFReoTfMGn4VyPSiEbK"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "010000000126ef5f9aa352644b960ae9cc4a3d9b732d585471a057063337df52dab58de64e01000000171600145183a8cd6827ed3249d2c667df4f5ce94ca88918ffffffff0300000000000000000f6a0d626974636f696e207375636b7332f5f802000000001976a914a579388225827d9f2fe9014add644487808c695d88ac80f0fa02000000001976a91454bd837a7dc2ea7f2b52ca0e1dcb07808e8acba988ac00000000",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "45d093731ae556580da86dfc0924fdbb12fb60386b7c6e91699316a9fe49e562",
+              "inputAddresses": [
+                "2N4BrUeq26v13gGDRNNWd6Q3L7ADp75Lqzp"
+              ],
+              "outputAddresses": [
+                null,
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "moF25oWYTeN6V5USsvHFEkZp8CR2KimVdu"
+              ],
+              "vsize": 166
+            },
+            {
+              "hex": "010000000162e549fea9169369916e7c6b3860fb12bbfd2409fc6da80d5856e51a7393d045010000006a473044022016caa29c3cfd6b51393cb231aff14d4dc939f09d1969ed6c195a360bda98e5e6022012426456c411a9a5cc6aeae6168471cf71ca23da6462db2d92d13423fe1ea99e0121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0ffffffff020000000000000000086a066b6f6b6f732150ebf802000000001976a9146365ed7bb4a092937ba40e502ace1f8fe71f2cd488ac00000000",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "545e31eac493e1e7afe8656504695ebcd8e56dda24dc5e8d6e9b8d7074b94c1b",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                null,
+                "mpaXJ6yWNAeJuEVuFReoTfMGn4VyPSiEbK"
+              ],
+              "vsize": 208
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Incoming only half mine, other input from same tx but not mine output",
+    "note": "Edgecase - tx spends two utxos from same tx, but only one mine",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 55000000,
+          "transactionHash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            2
+          ],
+          "vsize": 340,
+          "tsize": 340,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+          "targets": [
+            {
+              "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+              "value": 55000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 25157095,
+          "myOutputs": {
+            "0": {
+              "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+              "value": 55000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "index": 0
+            },
+            {
+              "id": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "index": 1
+            }
+          ],
+          "tsize": 340,
+          "vsize": 340,
+          "balance": 55000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 29842905,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 29842905,
+          "myOutputs": {
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 29842905,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "4daefcde25b5e73394fc0e1a134816ea2e22969e77c78c95f2ed669533318306",
+              "index": 1
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 29842905
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 29842905
+        },
+        {
+          "address": "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+          "received": 0
+        },
+        {
+          "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+          "received": 55000000
+        }
+      ],
+      "unusedAddresses": [
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+        "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
+        "muXZYKRJFJ2qPegzV2GEzLqHxngJpzMrmT"
+      ],
+      "lastConfirmedMain": 2,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 55000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": [
+            {
+              "hex": "0100000001068331339566edf2958cc7779e96222eea1648131a0efc9433e7b525defcae4d010000006a4730440220645c41ae3da2060dce3e4b84fdf9ec92a06946c8d22387d2d239ebcebab0e9a202203359b824fd5461457279937b32c0419a9826994c619e5e9a1bf3c7e498a5b2cd012102eae43d38a39b8ffdccd78afd77c347e86d57337df0cc254a33b634964fd187d8ffffffff0260198501000000001976a91454bd837a7dc2ea7f2b52ca0e1dcb07808e8acba988acd95dc701000000001976a914a579388225827d9f2fe9014add644487808c695d88ac00000000",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "inputAddresses": [
+                "n2wHFh9Yg3ABfnMJYQBexYxw2znKMbDjt6"
+              ],
+              "outputAddresses": [
+                "moF25oWYTeN6V5USsvHFEkZp8CR2KimVdu",
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "vsize": 225
+            },
+            {
+              "hex": "0100000002ea3fc8d0564e5cfdcaf91908d873858ea8b7af13539d8143c13bde4f7096378b000000006b483045022100b8e21e1f0b6e22f9d76cffb5af6eda58e770bba27d6b149c6a04e5a0189c5960022032d830753273aba46213d3b1a60c58ac58603695fe714488a74fe5f2712ac2e80121039f3759a2be6cebc05a641d2fe8a70c705584eb970ffb6003ad88f0e53550005200000000ea3fc8d0564e5cfdcaf91908d873858ea8b7af13539d8143c13bde4f7096378b010000006b483045022100dd4dbf0890992fb48ec682a6158e18c29060cd3ecc4c13717d3a58eca89eed2d02206f5b9424b2a1b3a65043da27e874dd6cf11cde2a4991c0f3e8e5bccbb1741e8c0121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd00000000001c03b4703000000001976a9140ef03659a93ae1f10644e975a253e8108ee8b0a788ac00000000",
+              "zcash": false,
+              "height": 150,
+              "timestamp": 1525483226,
+              "hash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+              "inputAddresses": [
+                "moF25oWYTeN6V5USsvHFEkZp8CR2KimVdu"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+              ],
+              "vsize": 340
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
+            "muXZYKRJFJ2qPegzV2GEzLqHxngJpzMrmT"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 200,
+          "end": 0,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Incoming only half mine, from itself",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 55000000,
+          "transactionHash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            2
+          ],
+          "vsize": 340,
+          "tsize": 340,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+          "targets": [
+            {
+              "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+              "value": 55000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 25157095,
+          "myOutputs": {
+            "0": {
+              "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+              "value": 55000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "index": 0
+            },
+            {
+              "id": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "index": 1
+            }
+          ],
+          "tsize": 340,
+          "vsize": 340,
+          "balance": 55000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 29842905,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 29842905,
+          "myOutputs": {
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 29842905,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "4daefcde25b5e73394fc0e1a134816ea2e22969e77c78c95f2ed669533318306",
+              "index": 1
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 29842905
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 29842905
+        },
+        {
+          "address": "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+          "received": 0
+        },
+        {
+          "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+          "received": 55000000
+        }
+      ],
+      "unusedAddresses": [
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+        "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
+        "muXZYKRJFJ2qPegzV2GEzLqHxngJpzMrmT"
+      ],
+      "lastConfirmedMain": 2,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 55000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 55000000,
+          "transactionHash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            2
+          ],
+          "vsize": 340,
+          "tsize": 340,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "add909c0e446573eefdff6fd8b50ba9b11f5102c124e7362e170f63f0a5df1cb",
+          "targets": [
+            {
+              "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+              "value": 55000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 25157095,
+          "myOutputs": {
+            "0": {
+              "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+              "value": 55000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "index": 0
+            },
+            {
+              "id": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+              "index": 1
+            }
+          ],
+          "tsize": 340,
+          "vsize": 340,
+          "balance": 55000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "8b3796704fde3bc143819d5313afb7a88e8573d80819f9cafd5c4e56d0c83fea",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 29842905,
+              "i": 1
+            }
+          ],
+          "type": "recv",
+          "value": 29842905,
+          "myOutputs": {
+            "1": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 29842905,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "4daefcde25b5e73394fc0e1a134816ea2e22969e77c78c95f2ed669533318306",
+              "index": 1
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 29842905
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 29842905
+        },
+        {
+          "address": "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+          "received": 0
+        },
+        {
+          "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+          "received": 55000000
+        }
+      ],
+      "unusedAddresses": [
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+        "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
+        "muXZYKRJFJ2qPegzV2GEzLqHxngJpzMrmT"
+      ],
+      "lastConfirmedMain": 2,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 55000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
+            "muXZYKRJFJ2qPegzV2GEzLqHxngJpzMrmT",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 200
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 200,
+          "end": 200,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt",
+            "muXZYKRJFJ2qPegzV2GEzLqHxngJpzMrmT"
+          ],
+          "start": 200,
+          "end": 200,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 200,
+          "end": 200,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Two incoming, one dependent on other, first cleaned up outputs",
+    "note": "Testing other edgecase - second incoming tx spends output that has same tx that is in my history, but is not mine. We clean up outputs that are not mine when returning state, so the tx info *is* in past transactions, but *not* the output, but that should be fine.",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 100000000,
+          "transactionHash": "05fa57d2bf09aaf270b41011e2b0ae944e43ccb64ce42d1f1f7767da336b7516",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "05fa57d2bf09aaf270b41011e2b0ae944e43ccb64ce42d1f1f7767da336b7516",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 100000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "f14b99aaec8300411c4d3856dbd65b3f9c55329aed8e19af1a383b4e4a9d1f90",
+              "index": 0
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 100000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 100000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 100000000,
+      "lastBlock": {
+        "hash": "000000000000dead200",
+        "height": 200
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 100000000,
+          "transactionHash": "05fa57d2bf09aaf270b41011e2b0ae944e43ccb64ce42d1f1f7767da336b7516",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        },
+        {
+          "index": 0,
+          "value": 100000000,
+          "transactionHash": "b9d775bd2094ba881803838ca6e51115115b0b35d426ea34b375681854065eee",
+          "height": 201,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 201,
+          "confirmations": 1,
+          "hash": "b9d775bd2094ba881803838ca6e51115115b0b35d426ea34b375681854065eee",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 100000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "05fa57d2bf09aaf270b41011e2b0ae944e43ccb64ce42d1f1f7767da336b7516",
+              "index": 1
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 200000000
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 51,
+          "hash": "05fa57d2bf09aaf270b41011e2b0ae944e43ccb64ce42d1f1f7767da336b7516",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 100000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 100000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "f14b99aaec8300411c4d3856dbd65b3f9c55329aed8e19af1a383b4e4a9d1f90",
+              "index": 0
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 100000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 200000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 200000000,
+      "lastBlock": {
+        "hash": "000000000000dead201",
+        "height": 201
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 201
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 201,
+          "resultError": false,
+          "result": "000000000000dead201"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 200,
+          "resultError": false,
+          "result": "000000000000dead200"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 201,
+          "end": 200,
+          "result": [
+            {
+              "hex": "010000000116756b33da67771f1f2de44cb6cc434e94aeb0e21110b470f2aa09bfd257fa05010000006a473044022026db6f2951c736f69223f7ea9c903454d0e0fd9289b5cfed0616d3ef81a484bb02203a8cd24fb4508d198d6bdc3cc4079dc18cf8c5480b4a50440842dfa97126c3740121038b478543fd1f8a73f73dbce135f03ff4f6e8e3dccbe9378e379a378341eac11dffffffff0200e1f505000000001976a914a579388225827d9f2fe9014add644487808c695d88ac1f49bd15000000001976a91448f7578ee2edad305f23d25d5b9da735bd870c1a88ac00000000",
+              "zcash": false,
+              "height": 201,
+              "timestamp": 1525483226,
+              "hash": "b9d775bd2094ba881803838ca6e51115115b0b35d426ea34b375681854065eee",
+              "inputAddresses": [
+                "n48agDCKBPbMLu1FYSKEpFJLradG3wgdY9"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mnAmFVRixSKzBc5ZfDAbyZSR7YTw51DVp3"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 201,
+          "end": 200,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 201,
+          "end": 200,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Nonsensical tx",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "endError": "Error transaction parsing",
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 101
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 101,
+          "resultError": false,
+          "result": "000000000000deadbeef"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 101,
+          "end": 0,
+          "result": [
+            {
+              "hex": "f00f00feefeef00f00feefee",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "inputAddresses": [
+                "n27f1mtCMZAJbauRVmzbNKQptc5istpJoi"
+              ],
+              "outputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+                "mssXejqtZgHv4r4SCTpdJLZtELKQtwRhXh"
+              ],
+              "vsize": 226
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "Sending to self",
+    "start": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 130000000,
+          "transactionHash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "height": 150,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            0
+          ],
+          "vsize": 226,
+          "tsize": 226,
+          "own": false
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 0,
+      "balance": 130000000,
+      "lastBlock": {
+        "hash": "000000000000dead202",
+        "height": 202
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "end": {
+      "utxos": [
+        {
+          "index": 0,
+          "value": 33333333,
+          "transactionHash": "d60a6f33aa816323d8d7aa8cfa464ee226ab01c31e8e6afb6136543837d3981b",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            0,
+            3
+          ],
+          "vsize": 225,
+          "tsize": 226,
+          "own": true
+        },
+        {
+          "index": 1,
+          "value": 33333333,
+          "transactionHash": "d60a6f33aa816323d8d7aa8cfa464ee226ab01c31e8e6afb6136543837d3981b",
+          "height": null,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 226,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": null,
+          "dateInfoDayFormat": null,
+          "dateInfoTimeFormat": null,
+          "height": null,
+          "confirmations": null,
+          "hash": "d60a6f33aa816323d8d7aa8cfa464ee226ab01c31e8e6afb6136543837d3981b",
+          "targets": [],
+          "type": "self",
+          "value": -63333334,
+          "myOutputs": {
+            "0": {
+              "address": "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+              "value": 33333333,
+              "i": 0
+            },
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 226,
+          "vsize": 225,
+          "balance": 66666666
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        },
+        {
+          "address": "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+          "received": 0
+        },
+        {
+          "address": "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+          "received": 0
+        },
+        {
+          "address": "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+          "received": 33333333
+        }
+      ],
+      "unusedAddresses": [],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": -1,
+      "changeIndex": 1,
+      "balance": 66666666,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {},
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 202,
+          "resultError": false,
+          "result": "000000000000dead202"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006b483045022100b0bb6101c2869886eb7da48ac4a105ec04fcaafe7656d7b320b69ec646c48cca022034884c7aef185aac6591d86f370c0232f41a2f04b42363cc0771371242dba0290121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a9145a9452b8db22e7fb606adafc731f5d4b482f9e8d88ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "d60a6f33aa816323d8d7aa8cfa464ee226ab01c31e8e6afb6136543837d3981b",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 202,
+          "result": [
+            {
+              "hex": "0100000001b78fd4b250c46cde88d1aca908de8bc5086e862e18d8c3d342959c1556268a77000000006b483045022100b0bb6101c2869886eb7da48ac4a105ec04fcaafe7656d7b320b69ec646c48cca022034884c7aef185aac6591d86f370c0232f41a2f04b42363cc0771371242dba0290121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0000000000255a0fc01000000001976a9145a9452b8db22e7fb606adafc731f5d4b482f9e8d88ac55a0fc01000000001976a9143d3cca567e00a04819742b21a696a67da796498b88ac00000000",
+              "zcash": false,
+              "height": null,
+              "timestamp": null,
+              "hash": "d60a6f33aa816323d8d7aa8cfa464ee226ab01c31e8e6afb6136543837d3981b",
+              "inputAddresses": [
+                "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
+              ],
+              "outputAddresses": [
+                "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+                "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ"
+              ],
+              "vsize": 225
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "Inconsistent info",
+    "comment": "When counting inside worker gives nonsense result. Note: this should never happen; in theory, we can re-start the discovery, but that COULD cause infinite loop, maybe better to throw error",
+    "start": {
+      "utxos": [
+        {
+          "index": 1,
+          "value": 33333335,
+          "transactionHash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "height": 222,
+          "coinbase": false,
+          "addressPath": [
+            1,
+            0
+          ],
+          "vsize": 225,
+          "tsize": 225,
+          "own": true
+        }
+      ],
+      "transactions": [
+        {
+          "isCoinbase": false,
+          "timestamp": 1530847194,
+          "dateInfoDayFormat": "2018-07-06",
+          "dateInfoTimeFormat": "05:19:54",
+          "height": 222,
+          "confirmations": 29,
+          "hash": "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928",
+          "targets": [
+            {
+              "address": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm",
+              "value": 33333333,
+              "i": 0
+            }
+          ],
+          "type": "sent",
+          "value": -96666667,
+          "myOutputs": {
+            "1": {
+              "address": "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+              "value": 33333333,
+              "i": 1
+            }
+          },
+          "inputs": [
+            {
+              "id": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+              "index": 0
+            }
+          ],
+          "tsize": 225,
+          "vsize": 225,
+          "balance": 33333333
+        },
+        {
+          "isCoinbase": false,
+          "timestamp": 1525483226,
+          "dateInfoDayFormat": "2018-05-05",
+          "dateInfoTimeFormat": "03:20:26",
+          "height": 150,
+          "confirmations": 53,
+          "hash": "778a2656159c9542d3c3d8182e866e08c58bde08a9acd188de6cc450b2d48fb7",
+          "targets": [
+            {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          ],
+          "type": "recv",
+          "value": 130000000,
+          "myOutputs": {
+            "0": {
+              "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+              "value": 130000000,
+              "i": 0
+            }
+          },
+          "inputs": [
+            {
+              "id": "3c8570194b4ab720d1a726e92b9cfc18104d2256e11ee7af2efe37167274ba0a",
+              "index": 1
+            }
+          ],
+          "tsize": 226,
+          "vsize": 226,
+          "balance": 130000000
+        }
+      ],
+      "usedAddresses": [
+        {
+          "address": "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+          "received": 130000000
+        }
+      ],
+      "unusedAddresses": [
+        "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+        "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+        "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+      ],
+      "lastConfirmedMain": 0,
+      "lastConfirmedChange": 0,
+      "changeIndex": 1,
+      "balance": 33333333,
+      "lastBlock": {
+        "hash": "000000000000dead250",
+        "height": 250
+      },
+      "sentAddresses": {
+        "7fefacd62d75e857c826437904b2e5d514280c72cc7b02c1b67252533158a928:0": "mvGnbHiYbYbpuwBhTHRXfZHjjcmSWKn5nm"
+      },
+      "changeAddresses": [
+        "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+        "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+        "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+        "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+      ],
+      "allowChange": true,
+      "version": 5
+    },
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "endError": "Inconsistent info.",
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP",
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA",
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L",
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ]
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 250
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 250,
+          "resultError": false,
+          "result": "000000000000dead250"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "momtnzR3XqXgDSsFmd8gkGxUiHZLde3RmA"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mm6kLYbGEL1tGe4ZA8xacfgRPdW1NLjCbZ",
+            "mjXZwmEi1z1MzveZrKUAo4DBgbdq4sBYT6",
+            "mvukVu96xM1QJ971w4Z5cdX4tsJwDyQy2L"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mwX7MfiyC4HJRE9Z4KqGMXC11TPZuzAyVB"
+          ],
+          "start": 250,
+          "end": 250,
+          "result": []
+        }
+      }
+    ]
+  },
+  {
+    "name": "Error in bitcore call propagates out of discovery",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "endError": "Error in lookup",
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": "Error in lookup"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Error in bitcore call propagates out of discovery - 2",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431VnevzzzK3U",
+    "endError": "Lookup error",
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": [
+      {
+        "type": "call",
+        "spec": {
+          "type": "subscribe",
+          "addresses": []
+        }
+      },
+      {
+        "type": "emit",
+        "spec": {
+          "type": "block"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupSyncStatus",
+          "result": {
+            "height": 100
+          }
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupBlockHash",
+          "height": 100,
+          "resultError": false,
+          "result": "0000000000001b3afd3d78092bfa239e212585aaf99cce5f39c407989ff6352f"
+        }
+      },
+      {
+        "type": "call",
+        "spec": {
+          "type": "lookupTransactionsStream",
+          "addresses": [
+            "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            "mopZWqZZyQc3F2Sy33cvDtJchSAMsnLi7b",
+            "mgswWyysmViMqYmn5XEj1pVz7rVUftVEBP"
+          ],
+          "start": 100,
+          "end": 0,
+          "result": "Lookup error"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Nonsensical xpub",
+    "start": null,
+    "xpub": "tpubDDKn3FtHc74CaRrRbi1WFdJNaaenZkDWqq9NsEhcafnDZ4VuKeuLG2aKHm5SuwuLgAhRkkfHqcCxpnVNSrs5kJYZXwa6Ud431Vaaaaaaaaa",
+    "endError": "Invalid checksum",
+    "network": {
+      "messagePrefix": "N/A",
+      "bip32": {
+        "public": 70617039,
+        "private": 0
+      },
+      "pubKeyHash": 111,
+      "scriptHash": 196,
+      "bech32": "tb",
+      "wif": 0
+    },
+    "segwit": "off",
+    "cashaddr": false,
+    "gap": 3,
+    "timeOffset": -120,
+    "spec": []
+  }
+]

--- a/test/monitor-account.js
+++ b/test/monitor-account.js
@@ -1,0 +1,93 @@
+/* global it:false, describe:false, WebAssembly:true */
+
+import {MockBitcore} from '../src/mock-bitcore';
+import {WorkerDiscovery} from '../src/discovery/worker-discovery';
+import fixtures from './fixtures/monitor-account.json';
+
+import {discoveryWorkerFactory, xpubWorker, xpubFilePromise} from './_worker-helper';
+
+const hasWasm = typeof WebAssembly !== 'undefined';
+if (hasWasm) {
+    monitorAccount(true);
+}
+monitorAccount(false);
+
+function monitorAccount(enableWebassembly) {
+    const desc = enableWebassembly ? ' wasm' : ' no wasm';
+    describe('monitor account' + desc, () => {
+        fixtures.forEach(fixture_orig => {
+            const fixture = JSON.parse(JSON.stringify(fixture_orig));
+            it(fixture.name, function (done_orig) {
+                this.timeout(30 * 1000);
+                let wasm_old;
+                if (!enableWebassembly && hasWasm) {
+                    wasm_old = WebAssembly;
+                    WebAssembly = undefined;
+                }
+                const spec = fixture.spec;
+                /* const spec = [{
+                    type: "emitter",
+                    spec: {
+                      type: "block"
+                    }
+                },
+                ...fixture.spec
+                ];*/
+                const done_wasm = (x) => {
+                    if (!enableWebassembly && hasWasm) {
+                        WebAssembly = wasm_old;
+                    }
+                    done_orig(x);
+                };
+                const blockchain = new MockBitcore(spec, done_wasm);
+                const discovery = new WorkerDiscovery(discoveryWorkerFactory, xpubWorker, xpubFilePromise, blockchain);
+                const stream = discovery.monitorAccountActivity(
+                    fixture.start,
+                    fixture.xpub,
+                    fixture.network,
+                    fixture.segwit,
+                    fixture.cashaddr,
+                    fixture.gap,
+                    fixture.timeOffset,
+                );
+                const done = (x) => {
+                    stream.dispose();
+                    done_wasm(x);
+                };
+
+                stream.values.attach(res => {
+                    if (!(res instanceof Error)) {
+                        if (!blockchain.errored) {
+                            if (JSON.stringify(res) !== JSON.stringify(fixture.end)) {
+                                console.log('Discovery result', JSON.stringify(res, null, 2));
+                                console.log('Fixture', JSON.stringify(fixture.end, null, 2));
+                                done(new Error('Result not the same'));
+                            } else {
+                                if (blockchain.spec.length > 0) {
+                                    console.log(JSON.stringify(blockchain.spec));
+                                    done(new Error('Some spec left on end'));
+                                } else {
+                                    done();
+                                }
+                            }
+                        }
+                    } else {
+                        const err = res.message;
+                        if (!(err.startsWith(fixture.endError))) {
+                            console.log('Discovery result', JSON.stringify(err, null, 2));
+                            console.log('Fixture', JSON.stringify(fixture.endError, null, 2));
+                            done(new Error('Result not the same'));
+                        } else {
+                            if (blockchain.spec.length > 0) {
+                                console.log(JSON.stringify(blockchain.spec));
+                                done(new Error('Some spec left on end'));
+                            } else {
+                                done();
+                            }
+                        }
+                    }
+                });
+            });
+        });
+    });
+}

--- a/test/test_bitcore/bitcore.js
+++ b/test/test_bitcore/bitcore.js
@@ -101,7 +101,7 @@ const socketWorkerFactory = () => {
     if (typeof Worker === 'undefined') {
         const TinyWorker = require('tiny-worker');
         return new TinyWorker(() => {
-            require('babel-register');
+            require('@babel/register');
             require('../../../src/socketio-worker/inside.js');
         });
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,651 @@
 # yarn lockfile v1
 
 
+"@babel/cli@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.2.0.tgz#505ed8d351daee6a88918da02c046c18c8c5a24f"
+  integrity sha512-FLteTkEoony0DX8NbnT51CmwmLBzINdlXmiJCSqCLmqWCDA/xk8EITPWqwDnVLbuK0bsZONt/grqHnQzQ15j0Q==
+  dependencies:
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    output-file-sync "^2.0.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.0.3"
+
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.0.tgz#a4dd3814901998e93340f0086e9867fefa163ada"
+  integrity sha512-7pvAdC4B+iKjFFp9Ztj0QgBndJ++qaMeonT185wAqUnhipw8idm9Rv1UMyBuKtYjfl6ORNkgEgcsYLfHX/GpLw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.2.0"
+    "@babel/helpers" "^7.2.0"
+    "@babel/parser" "^7.2.0"
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.2.0"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.10"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.0.0", "@babel/generator@^7.1.6", "@babel/generator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.0.tgz#eaf3821fa0301d9d4aef88e63d4bcc19b73ba16c"
+  integrity sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==
+  dependencies:
+    "@babel/types" "^7.2.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  integrity sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f"
+  integrity sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==
+  dependencies:
+    "@babel/helper-explode-assignable-expression" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-call-delegate@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz#6a957f105f37755e8645343d3038a22e1449cc4a"
+  integrity sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-create-class-features-plugin@^7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.2.1.tgz#f6e8027291669ef64433220dc8327531233f1161"
+  integrity sha512-EsEP7XLFmcJHjcuFYBxYD1FkP0irC8C9fsrt2tX/jrAi/eTnFI6DOPgVFb+WREeg1GboF+Ib+nCHbGBodyAXSg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+
+"@babel/helper-define-map@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c"
+  integrity sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/helper-explode-assignable-expression@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6"
+  integrity sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-hoist-variables@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz#46adc4c5e758645ae7a45deb92bab0918c23bb88"
+  integrity sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-member-expression-to-functions@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
+  integrity sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-transforms@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz#470d4f9676d9fad50b324cdcce5fbabbc3da5787"
+  integrity sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/helper-optimise-call-expression@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
+  integrity sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-plugin-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+  integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
+
+"@babel/helper-regex@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
+  integrity sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==
+  dependencies:
+    lodash "^4.17.10"
+
+"@babel/helper-remap-async-to-generator@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f"
+  integrity sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-wrap-function" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-replace-supers@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz#5fc31de522ec0ef0899dc9b3e7cf6a5dd655f362"
+  integrity sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-simple-access@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
+  integrity sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==
+  dependencies:
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+  integrity sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-wrap-function@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
+  integrity sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.2.0"
+
+"@babel/helpers@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.2.0.tgz#8335f3140f3144270dc63c4732a4f8b0a50b7a21"
+  integrity sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==
+  dependencies:
+    "@babel/template" "^7.1.2"
+    "@babel/traverse" "^7.1.5"
+    "@babel/types" "^7.2.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6", "@babel/parser@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
+  integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
+
+"@babel/plugin-proposal-async-generator-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
+  integrity sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+
+"@babel/plugin-proposal-class-properties@^7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.2.1.tgz#c734a53e0a1ec40fe5c22ee5069d26da3b187d05"
+  integrity sha512-/4FKFChkQ2Jgb8lBDsvFX496YTi7UWTetVgS8oJUpX1e/DlaoeEK57At27ug8Hu2zI2g8bzkJ+8k9qrHZRPGPA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.2.1"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-proposal-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
+  integrity sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.2.0.tgz#88f5fec3e7ad019014c97f7ee3c992f0adbf7fb8"
+  integrity sha512-1L5mWLSvR76XYUQJXkd/EEQgjq8HHRP6lQuZTTg0VA4tTGPpGemmCdAfQIz1rzEuWAm+ecP8PyyEm30jC1eQCg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5"
+  integrity sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520"
+  integrity sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.2.0"
+
+"@babel/plugin-syntax-async-generators@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
+  integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-flow@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz#a765f061f803bc48f240c26f8747faf97c26bf7c"
+  integrity sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
+  integrity sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-object-rest-spread@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
+  integrity sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
+  integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-arrow-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
+  integrity sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-async-to-generator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz#68b8a438663e88519e65b776f8938f3445b1a2ff"
+  integrity sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+
+"@babel/plugin-transform-block-scoped-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190"
+  integrity sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-block-scoping@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz#f17c49d91eedbcdf5dd50597d16f5f2f770132d4"
+  integrity sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.10"
+
+"@babel/plugin-transform-classes@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.0.tgz#374f8876075d7d21fea55aeb5c53561259163f96"
+  integrity sha512-aPCEkrhJYebDXcGTAP+cdUENkH7zqOlgbKwLbghjjHpJRJBWM/FSlCjMoPGA8oUdiMfOrk3+8EFPLLb5r7zj2w==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.1.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    globals "^11.1.0"
+
+"@babel/plugin-transform-computed-properties@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
+  integrity sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-destructuring@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz#e75269b4b7889ec3a332cd0d0c8cff8fed0dc6f3"
+  integrity sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-dotall-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz#f0aabb93d120a8ac61e925ea0ba440812dbe0e49"
+  integrity sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-duplicate-keys@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz#d952c4930f312a4dbfff18f0b2914e60c35530b3"
+  integrity sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-exponentiation-operator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz#a63868289e5b4007f7054d46491af51435766008"
+  integrity sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-flow-strip-types@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.2.0.tgz#db6180d098caaabdd609a8da3800f5204e66b69b"
+  integrity sha512-xhQp0lyXA5vk8z1kJitdMozQYEWfo4MgC6neNXrb5euqHiTIGhj5ZWfFPkVESInQSk9WZz1bbNmIRz6zKfWGVA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.2.0"
+
+"@babel/plugin-transform-for-of@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz#ab7468befa80f764bb03d3cb5eef8cc998e1cad9"
+  integrity sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-function-name@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz#f7930362829ff99a3174c39f0afcc024ef59731a"
+  integrity sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1"
+  integrity sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-amd@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz#82a9bce45b95441f617a24011dc89d12da7f4ee6"
+  integrity sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz#c4f1933f5991d5145e9cfad1dfd848ea1727f404"
+  integrity sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz#912bfe9e5ff982924c81d0937c92d24994bb9068"
+  integrity sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-umd@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz#7678ce75169f0877b8eb2235538c074268dd01ae"
+  integrity sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-new-target@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a"
+  integrity sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-object-super@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"
+  integrity sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+
+"@babel/plugin-transform-parameters@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz#0d5ad15dc805e2ea866df4dd6682bfe76d1408c2"
+  integrity sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==
+  dependencies:
+    "@babel/helper-call-delegate" "^7.1.0"
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-regenerator@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz#5b41686b4ed40bef874d7ed6a84bdd849c13e0c1"
+  integrity sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==
+  dependencies:
+    regenerator-transform "^0.13.3"
+
+"@babel/plugin-transform-shorthand-properties@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
+  integrity sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-spread@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.0.tgz#0c76c12a3b5826130078ee8ec84a7a8e4afd79c4"
+  integrity sha512-7TtPIdwjS/i5ZBlNiQePQCovDh9pAhVbp/nGVRBZuUdBiVRThyyLend3OHobc0G+RLCPPAN70+z/MAMhsgJd/A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-sticky-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz#a1e454b5995560a9c1e0d537dfc15061fd2687e1"
+  integrity sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+
+"@babel/plugin-transform-template-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz#d87ed01b8eaac7a92473f608c97c089de2ba1e5b"
+  integrity sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-typeof-symbol@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
+  integrity sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-unicode-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz#4eb8db16f972f8abb5062c161b8b115546ade08b"
+  integrity sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+    regexpu-core "^4.1.3"
+
+"@babel/preset-env@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.2.0.tgz#a5030e7e4306af5a295dd5d7c78dc5464af3fee2"
+  integrity sha512-haGR38j5vOGVeBatrQPr3l0xHbs14505DcM57cbJy48kgMFvvHHoYEhHuRV+7vi559yyAUAVbTWzbK/B/pzJng==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.2.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.2.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.2.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.2.0"
+    "@babel/plugin-transform-classes" "^7.2.0"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.2.0"
+    "@babel/plugin-transform-dotall-regex" "^7.2.0"
+    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.2.0"
+    "@babel/plugin-transform-function-name" "^7.2.0"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.2.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.2.0"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-new-target" "^7.0.0"
+    "@babel/plugin-transform-object-super" "^7.2.0"
+    "@babel/plugin-transform-parameters" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.2.0"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.2.0"
+    browserslist "^4.3.4"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.3.0"
+
+"@babel/register@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
+  integrity sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==
+  dependencies:
+    core-js "^2.5.7"
+    find-cache-dir "^1.0.0"
+    home-or-tmp "^3.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pirates "^4.0.0"
+    source-map-support "^0.5.9"
+
+"@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
+  integrity sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.1.2"
+    "@babel/types" "^7.1.2"
+
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.1.6":
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.6.tgz#c8db9963ab4ce5b894222435482bd8ea854b7b5c"
+  integrity sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.1.6"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
+"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
+  integrity sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
 "@types/node@^10.11.7":
   version "10.12.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
@@ -93,9 +738,21 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
 
 anymatch@^1.3.0:
   version "1.3.0"
@@ -104,15 +761,24 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+  integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+  dependencies:
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
 ap@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ap/-/ap-0.2.0.tgz#ae0942600b29912f0d2b14ec60c45e8f330b6110"
 
-append-transform@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  integrity sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
   dependencies:
-    default-require-extensions "^1.0.0"
+    default-require-extensions "^2.0.0"
 
 aproba@^1.0.3:
   version "1.1.1"
@@ -245,9 +911,12 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.4.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+async@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
+  dependencies:
+    lodash "^4.17.10"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -265,27 +934,6 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-cli@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
-  dependencies:
-    babel-core "^6.26.0"
-    babel-polyfill "^6.26.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    commander "^2.11.0"
-    convert-source-map "^1.5.0"
-    fs-readdir-recursive "^1.0.0"
-    glob "^7.1.2"
-    lodash "^4.17.4"
-    output-file-sync "^1.1.2"
-    path-is-absolute "^1.0.1"
-    slash "^1.0.0"
-    source-map "^0.5.6"
-    v8flags "^2.1.1"
-  optionalDependencies:
-    chokidar "^1.6.1"
-
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -293,62 +941,6 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
-
-babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
-
-babel-core@^6.0.14, babel-core@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-generator "^6.24.1"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
-    convert-source-map "^1.1.0"
-    debug "^2.1.1"
-    json5 "^0.5.0"
-    lodash "^4.2.0"
-    minimatch "^3.0.2"
-    path-is-absolute "^1.0.0"
-    private "^0.1.6"
-    slash "^1.0.0"
-    source-map "^0.5.0"
-
-babel-core@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.0"
-    debug "^2.6.8"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.7"
-    slash "^1.0.0"
-    source-map "^0.5.6"
 
 babel-eslint@^7.2.1:
   version "7.2.1"
@@ -359,426 +951,29 @@ babel-eslint@^7.2.1:
     babel-types "^6.23.0"
     babylon "^6.16.1"
 
-babel-generator@^6.18.0, babel-generator@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-babel-generator@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.17.4"
-    source-map "^0.5.6"
-    trim-right "^1.0.1"
-
-babel-helper-call-delegate@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz#119921b56120f17e9dae3f74b4f5cc7bcc1b37ef"
-  dependencies:
-    babel-helper-hoist-variables "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-helper-define-map@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz#1444f960c9691d69a2ced6a205315f8fd00804e7"
-  dependencies:
-    babel-helper-function-name "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    lodash "^4.2.0"
-
-babel-helper-function-name@^6.22.0, babel-helper-function-name@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz#25742d67175c8903dbe4b6cb9d9e1fcb8dcf23a6"
-  dependencies:
-    babel-helper-get-function-arity "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-
-babel-helper-get-function-arity@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz#0beb464ad69dc7347410ac6ade9f03a50634f5ce"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-helper-hoist-variables@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz#3eacbf731d80705845dd2e9718f600cfb9b4ba72"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-helper-optimise-call-expression@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz#f3ee7eed355b4282138b33d02b78369e470622f5"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-
-babel-helper-regex@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz#79f532be1647b1f0ee3474b5f5c3da58001d247d"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-    lodash "^4.2.0"
-
-babel-helper-replace-supers@^6.22.0, babel-helper-replace-supers@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz#eeaf8ad9b58ec4337ca94223bacdca1f8d9b4bfd"
-  dependencies:
-    babel-helper-optimise-call-expression "^6.23.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-
-babel-helpers@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-exports@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.1.2.tgz#4d389000c9dd3c988b3ed23004eb95e27b42de59"
+babel-plugin-istanbul@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.0.tgz#6892f529eff65a3e2d33d87dc5888ffa2ecd4a30"
+  integrity sha512-CLoXPRSUWiR8yao8bShqZUIC6qLfZVVY3X1wj+QPNXu0wfmrRRfarh1LYy+dYMVI+bDj0ghy3tuqFFRFZmL1Nw==
   dependencies:
-    babel-template "^6.0.16"
-    lodash "^3.10.1"
+    find-up "^3.0.0"
+    istanbul-lib-instrument "^3.0.0"
+    test-exclude "^5.0.0"
 
-babel-plugin-check-es2015-constants@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-istanbul@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
-  dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
-    find-up "^2.1.0"
-    istanbul-lib-instrument "^1.10.1"
-    test-exclude "^4.2.1"
-
-babel-plugin-syntax-class-properties@^6.3.13:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
-
-babel-plugin-syntax-flow@^6.3.13:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
-
-babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.3.13:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
-
-babel-plugin-transform-class-properties@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.4.0.tgz#6a301b23605111bf7146dab17534a56b98d0b43f"
-  dependencies:
-    babel-plugin-syntax-class-properties "^6.3.13"
-    babel-runtime "^5.0.0"
-
-babel-plugin-transform-es2015-arrow-functions@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-block-scoped-functions@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-block-scoping@^6.3.13:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz#e48895cf0b375be148cd7c8879b422707a053b51"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-    lodash "^4.2.0"
-
-babel-plugin-transform-es2015-classes@^6.3.13:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz#49b53f326202a2fd1b3bbaa5e2edd8a4f78643c1"
-  dependencies:
-    babel-helper-define-map "^6.23.0"
-    babel-helper-function-name "^6.23.0"
-    babel-helper-optimise-call-expression "^6.23.0"
-    babel-helper-replace-supers "^6.23.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-
-babel-plugin-transform-es2015-computed-properties@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz#7c383e9629bba4820c11b0425bdd6290f7f057e7"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.22.0"
-
-babel-plugin-transform-es2015-destructuring@^6.3.13:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-for-of@^6.3.13:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-function-name@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz#f5fcc8b09093f9a23c76ac3d9e392c3ec4b77104"
-  dependencies:
-    babel-helper-function-name "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-plugin-transform-es2015-literals@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-modules-commonjs@^6.3.13:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz#e921aefb72c2cc26cb03d107626156413222134f"
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-types "^6.23.0"
-
-babel-plugin-transform-es2015-object-super@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz#daa60e114a042ea769dd53fe528fc82311eb98fc"
-  dependencies:
-    babel-helper-replace-supers "^6.22.0"
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-parameters@^6.3.13:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz#3a2aabb70c8af945d5ce386f1a4250625a83ae3b"
-  dependencies:
-    babel-helper-call-delegate "^6.22.0"
-    babel-helper-get-function-arity "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-
-babel-plugin-transform-es2015-shorthand-properties@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz#8ba776e0affaa60bff21e921403b8a652a2ff723"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-plugin-transform-es2015-spread@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-sticky-regex@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz#ab316829e866ee3f4b9eb96939757d19a5bc4593"
-  dependencies:
-    babel-helper-regex "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-plugin-transform-es2015-template-literals@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-typeof-symbol@^6.3.13:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-transform-es2015-unicode-regex@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz#8d9cc27e7ee1decfe65454fb986452a04a613d20"
-  dependencies:
-    babel-helper-regex "^6.22.0"
-    babel-runtime "^6.22.0"
-    regexpu-core "^2.0.0"
-
-babel-plugin-transform-flow-strip-types@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.4.0.tgz#ed9d4782cd78bcff827d2da40d970bf94ed238e5"
-  dependencies:
-    babel-plugin-syntax-flow "^6.3.13"
-    babel-runtime "^5.0.0"
-
-babel-plugin-transform-object-rest-spread@6.3.13:
-  version "6.3.13"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.3.13.tgz#10c55bab8a002bab0f04c2fad2b9feab247f8cfb"
-  dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.3.13"
-    babel-runtime "^5.0.0"
-
-babel-plugin-transform-regenerator@^6.3.13:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz#65740593a319c44522157538d690b84094617ea6"
-  dependencies:
-    regenerator-transform "0.9.8"
-
-babel-plugin-transform-strict-mode@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz#e008df01340fdc87e959da65991b7e05970c8c7c"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
-babel-preset-es2015@6.3.13:
-  version "6.3.13"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.3.13.tgz#97dce7ef292e18cb9b2b7545d80c593c28d9517f"
-  dependencies:
-    babel-plugin-check-es2015-constants "^6.3.13"
-    babel-plugin-transform-es2015-arrow-functions "^6.3.13"
-    babel-plugin-transform-es2015-block-scoped-functions "^6.3.13"
-    babel-plugin-transform-es2015-block-scoping "^6.3.13"
-    babel-plugin-transform-es2015-classes "^6.3.13"
-    babel-plugin-transform-es2015-computed-properties "^6.3.13"
-    babel-plugin-transform-es2015-destructuring "^6.3.13"
-    babel-plugin-transform-es2015-for-of "^6.3.13"
-    babel-plugin-transform-es2015-function-name "^6.3.13"
-    babel-plugin-transform-es2015-literals "^6.3.13"
-    babel-plugin-transform-es2015-modules-commonjs "^6.3.13"
-    babel-plugin-transform-es2015-object-super "^6.3.13"
-    babel-plugin-transform-es2015-parameters "^6.3.13"
-    babel-plugin-transform-es2015-shorthand-properties "^6.3.13"
-    babel-plugin-transform-es2015-spread "^6.3.13"
-    babel-plugin-transform-es2015-sticky-regex "^6.3.13"
-    babel-plugin-transform-es2015-template-literals "^6.3.13"
-    babel-plugin-transform-es2015-typeof-symbol "^6.3.13"
-    babel-plugin-transform-es2015-unicode-regex "^6.3.13"
-    babel-plugin-transform-regenerator "^6.3.13"
-
-babel-register@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
-  dependencies:
-    babel-core "^6.24.1"
-    babel-runtime "^6.22.0"
-    core-js "^2.4.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.2.0"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.2"
-
-babel-register@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
-  dependencies:
-    babel-core "^6.26.0"
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.15"
-
-babel-runtime@^5.0.0:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
-  dependencies:
-    core-js "^1.0.0"
-
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.0.16, babel-template@^6.22.0, babel-template@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.16.0, babel-template@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
+babel-traverse@^6.23.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -792,21 +987,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.24.1:
+babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -815,29 +996,14 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
+babelify@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/babelify/-/babelify-10.0.0.tgz#fe73b1a22583f06680d8d072e25a1e0d1d1d7fb5"
+  integrity sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==
 
-babelify@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/babelify/-/babelify-7.2.0.tgz#584249bc5066b61f984b3e745ed855203c9ec73e"
-  dependencies:
-    babel-core "^6.0.14"
-    object-assign "^4.0.0"
-
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.16.1:
+babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -1062,7 +1228,7 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.1:
+braces@^2.3.0, braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   dependencies:
@@ -1270,6 +1436,15 @@ browserify@^14.0.0:
     vm-browserify "~0.0.1"
     xtend "^4.0.0"
 
+browserslist@^4.3.4:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.5.tgz#1a917678acc07b55606748ea1adf9846ea8920f7"
+  integrity sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==
+  dependencies:
+    caniuse-lite "^1.0.30000912"
+    electron-to-chromium "^1.3.86"
+    node-releases "^1.0.5"
+
 bs58@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-0.3.0.tgz#cb48107bf446727d3e17b21102da73ca89109588"
@@ -1309,6 +1484,11 @@ bs58check@^2.1.1:
   dependencies:
     bs58 "^4.0.0"
     create-hash "^1.1.0"
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-shims@^1.0.0:
   version "1.0.0"
@@ -1363,13 +1543,15 @@ cached-path-relative@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.1.tgz#d09c4b52800aa4c078e2dd81a869aac90d2e54e7"
 
-caching-transform@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1"
+caching-transform@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-2.0.0.tgz#e1292bd92d35b6e8b1ed7075726724b3bd64eea0"
+  integrity sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==
   dependencies:
-    md5-hex "^1.2.0"
-    mkdirp "^0.5.1"
-    write-file-atomic "^1.1.4"
+    make-dir "^1.0.0"
+    md5-hex "^2.0.0"
+    package-hash "^2.0.0"
+    write-file-atomic "^2.0.0"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1389,13 +1571,19 @@ camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 camelize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+
+caniuse-lite@^1.0.30000912:
+  version "1.0.30000916"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000916.tgz#3428d3f529f0a7b2bfaaec65e796037bdd433aab"
+  integrity sha512-D6J9jloPm2MPkg0PXcODLMQAJKkeixKO9xhqTUMvtd44MtTYMyyDXPQ2Lk9IgBq5FH0frwiPa/N/w8ncQf7kIQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1424,6 +1612,15 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 "charenc@>= 0.0.1":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
@@ -1443,20 +1640,30 @@ chokidar@^1.0.0, chokidar@^1.4.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
+chokidar@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
+  integrity sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
   dependencies:
-    anymatch "^1.3.0"
+    anymatch "^2.0.0"
     async-each "^1.0.0"
-    glob-parent "^2.0.0"
+    braces "^2.3.0"
+    glob-parent "^3.1.0"
     inherits "^2.0.1"
     is-binary-path "^1.0.0"
-    is-glob "^2.0.0"
+    is-glob "^4.0.0"
+    lodash.debounce "^4.0.8"
+    normalize-path "^2.1.1"
     path-is-absolute "^1.0.0"
     readdirp "^2.0.0"
+    upath "^1.0.5"
   optionalDependencies:
-    fsevents "^1.0.0"
+    fsevents "^1.2.2"
+
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1:
   version "1.0.3"
@@ -1495,12 +1702,13 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
   dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 co@^4.6.0:
@@ -1533,6 +1741,18 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
 colors@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -1564,13 +1784,14 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
-commander@^2.19.0:
+commander@^2.19.0, commander@^2.8.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
+commander@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1642,13 +1863,16 @@ convert-hex@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/convert-hex/-/convert-hex-0.1.0.tgz#08c04568922c27776b8a2e81a95d393362ea0b65"
 
-convert-source-map@^1.1.0, convert-source-map@^1.1.3, convert-source-map@^1.3.0:
+convert-source-map@^1.1.0, convert-source-map@^1.1.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.4.0.tgz#e3dad195bf61bfe13a7a3c73e9876ec14a0268f3"
 
-convert-source-map@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+convert-source-map@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 convert-source-map@~0.2.3:
   version "0.2.6"
@@ -1670,17 +1894,14 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
 core-js@^2.2.0, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-core-js@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+core-js@^2.5.7:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
+  integrity sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1714,6 +1935,15 @@ cross-spawn@^4:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 "crypt@>= 0.0.1":
@@ -1768,6 +1998,11 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
+debug-log@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+  integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
+
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -1786,11 +2021,25 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
-debug@^2.3.3, debug@^2.6.8:
+debug@^2.1.2, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -1800,6 +2049,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -1808,11 +2062,12 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+  integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
   dependencies:
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -1877,11 +2132,10 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
-detect-indent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
-  dependencies:
-    repeating "^2.0.0"
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detective@^4.0.0, detective@~4.1.0:
   version "4.1.1"
@@ -2003,6 +2257,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+electron-to-chromium@^1.3.86:
+  version "1.3.88"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz#f36ab32634f49ef2b0fdc1e82e2d1cc17feb29e7"
+  integrity sha512-UPV4NuQMKeUh1S0OWRvwg0PI8ASHN9kBC8yDTk1ROXLC85W5GnhTRu/MZu3Teqx3JjlQYuckuHYXSUSgtb3J+A==
+
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
@@ -2068,9 +2327,10 @@ ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
 
-error-ex@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -2088,6 +2348,11 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
+
+es6-error@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
 es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.1"
@@ -2317,6 +2582,19 @@ evp_bytestokey@^1.0.0:
   dependencies:
     create-hash "^1.1.1"
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -2481,30 +2759,40 @@ finalhandler@1.0.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
-find-cache-dir@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+find-cache-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  integrity sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=
   dependencies:
     commondir "^1.0.1"
-    mkdirp "^0.5.1"
-    pkg-dir "^1.0.0"
+    make-dir "^1.0.0"
+    pkg-dir "^2.0.0"
+
+find-cache-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
+  integrity sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^3.0.0"
 
 find-parent-dir@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-
-find-up@^1.0.0, find-up@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
-  dependencies:
-    path-exists "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.2.2"
@@ -2529,7 +2817,7 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
-foreground-child@^1.5.3, foreground-child@^1.5.6:
+foreground-child@^1.5.6:
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
   dependencies:
@@ -2560,7 +2848,14 @@ fs-access@^1.0.0:
   dependencies:
     null-check "^1.0.0"
 
-fs-readdir-recursive@^1.0.0:
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+  dependencies:
+    minipass "^2.2.1"
+
+fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
 
@@ -2574,6 +2869,14 @@ fsevents@^1.0.0:
   dependencies:
     nan "^2.3.0"
     node-pre-gyp "^0.6.29"
+
+fsevents@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
+  integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
 
 fstream-ignore@~1.0.5:
   version "1.0.5"
@@ -2609,6 +2912,20 @@ gauge@~2.7.1:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
 generate-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
@@ -2622,6 +2939,11 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -2646,6 +2968,14 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
 glob@7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
@@ -2667,7 +2997,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -2678,9 +3008,10 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2696,13 +3027,14 @@ global@^4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
+globals@^11.1.0:
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249"
+  integrity sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==
+
 globals@^9.0.0, globals@^9.14.0:
   version "9.16.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.16.0.tgz#63e903658171ec2d9f51b1d31de5e2b8dc01fb80"
-
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -2723,7 +3055,7 @@ globo@~1.1.0:
     is-defined "~1.0.0"
     ternary "~1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2735,15 +3067,16 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
-handlebars@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
+handlebars@^4.0.11:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
+  integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
   dependencies:
-    async "^1.4.0"
+    async "^2.5.0"
     optimist "^0.6.1"
-    source-map "^0.4.4"
+    source-map "^0.6.1"
   optionalDependencies:
-    uglify-js "^2.6"
+    uglify-js "^3.1.4"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -2775,6 +3108,11 @@ has-cors@1.1.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-require@~1.2.1:
   version "1.2.2"
@@ -2850,12 +3188,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-home-or-tmp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.1"
+home-or-tmp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
+  integrity sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=
 
 hosted-git-info@^2.1.4:
   version "2.4.1"
@@ -2901,9 +3237,23 @@ iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
+iconv-lite@^0.4.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 ignore@^3.2.0:
   version "3.2.7"
@@ -2985,9 +3335,16 @@ interpret@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.2.tgz#f4f623f0bb7122f15f5717c8e254b8161b5c5b2d"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
+
+invariant@^2.2.2:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
 
@@ -3087,11 +3444,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  dependencies:
-    number-is-nan "^1.0.0"
+is-extglob@^2.1.0, is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -3108,6 +3464,20 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
+  dependencies:
+    is-extglob "^2.1.0"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-my-json-valid@^2.10.0:
   version "2.16.0"
@@ -3154,6 +3524,11 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -3178,17 +3553,13 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -3231,67 +3602,57 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.2.tgz#87a0c015b6910651cb3b184814dfb339337e25e1"
+istanbul-lib-coverage@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#2aee0e073ad8c5f6a0b00e0dfbf52b4667472eda"
+  integrity sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==
 
-istanbul-lib-coverage@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
-
-istanbul-lib-hook@^1.0.0-alpha.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.5.tgz#6ca3d16d60c5f4082da39f7c5cd38ea8a772b88e"
+istanbul-lib-hook@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.1.tgz#918a57b75a0f951d552a08487ca1fa5336433d72"
+  integrity sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==
   dependencies:
-    append-transform "^0.4.0"
+    append-transform "^1.0.0"
 
-istanbul-lib-instrument@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
+istanbul-lib-instrument@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz#b5f066b2a161f75788be17a9d556f40a0cf2afc9"
+  integrity sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==
   dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.18.0"
-    istanbul-lib-coverage "^1.2.0"
-    semver "^5.3.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    istanbul-lib-coverage "^2.0.1"
+    semver "^5.5.0"
 
-istanbul-lib-instrument@^1.2.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz#b8e0dc25709bb44e17336ab47b7bb5c97c23f659"
+istanbul-lib-report@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.2.tgz#430a2598519113e1da7af274ba861bd42dd97535"
+  integrity sha512-rJ8uR3peeIrwAxoDEbK4dJ7cqqtxBisZKCuwkMtMv0xYzaAnsAi3AHrHPAAtNXzG/bcCgZZ3OJVqm1DTi9ap2Q==
   dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.13.0"
-    istanbul-lib-coverage "^1.0.2"
-    semver "^5.3.0"
+    istanbul-lib-coverage "^2.0.1"
+    make-dir "^1.3.0"
+    supports-color "^5.4.0"
 
-istanbul-lib-report@^1.0.0-alpha.3:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.0.0.tgz#d83dac7f26566b521585569367fe84ccfc7aaecb"
+istanbul-lib-source-maps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-2.0.1.tgz#ce8b45131d8293fdeaa732f4faf1852d13d0a97e"
+  integrity sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==
   dependencies:
-    istanbul-lib-coverage "^1.0.2"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
+    debug "^3.1.0"
+    istanbul-lib-coverage "^2.0.1"
+    make-dir "^1.3.0"
+    rimraf "^2.6.2"
+    source-map "^0.6.1"
 
-istanbul-lib-source-maps@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.1.tgz#f8c8c2e8f2160d1d91526d97e5bd63b2079af71c"
+istanbul-reports@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.0.1.tgz#fb8d6ea850701a3984350b977a969e9a556116a7"
+  integrity sha512-CT0QgMBJqs6NJLF678ZHcquUAZIoBIUNzdJrRJfpkI9OnzG6MkUfHxbJC3ln981dMswC7/B1mfX3LNkhgJxsuw==
   dependencies:
-    istanbul-lib-coverage "^1.0.2"
-    mkdirp "^0.5.1"
-    rimraf "^2.4.4"
-    source-map "^0.5.3"
-
-istanbul-reports@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.0.2.tgz#4e8366abe6fa746cc1cd6633f108de12cc6ac6fa"
-  dependencies:
-    handlebars "^4.0.3"
+    handlebars "^4.0.11"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -3308,6 +3669,11 @@ js-beautify@^1.5.4:
     mkdirp "~0.5.0"
     nopt "~4.0.1"
 
+js-levenshtein@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.4.tgz#3a56e3cbf589ca0081eb22cd9ba0b1290a16d26e"
+  integrity sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==
+
 js-string-escape@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
@@ -3316,9 +3682,10 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.5.1:
   version "3.8.3"
@@ -3331,17 +3698,24 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsesc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
-
 jsesc@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+  integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -3367,9 +3741,12 @@ json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
-json5@^0.5.0, json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  dependencies:
+    minimist "^1.2.0"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -3512,21 +3889,29 @@ lexical-scope@^1.2.0:
   dependencies:
     astw "^2.0.0"
 
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
   dependencies:
     graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
   dependencies:
     p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 lodash._baseassign@^3.0.0:
@@ -3560,6 +3945,16 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3584,9 +3979,14 @@ lodash@^3.10.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.10:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log4js@^0.6.31:
   version "0.6.38"
@@ -3623,6 +4023,13 @@ lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+make-dir@^1.0.0, make-dir@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
+
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -3637,9 +4044,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-md5-hex@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
+md5-hex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-2.0.0.tgz#d0588e9f1c74954492ecd24ac0ac6ce997d92e33"
+  integrity sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=
   dependencies:
     md5-o-matic "^0.1.1"
 
@@ -3651,11 +4059,25 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
+  dependencies:
+    mimic-fn "^1.0.0"
+
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
+
 merkle-lib@^2.0.10:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
 
-micromatch@^2.1.5, micromatch@^2.3.11:
+micromatch@^2.1.5:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -3673,7 +4095,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.8:
+micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -3711,6 +4133,11 @@ mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
 mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -3756,6 +4183,21 @@ minimist@0.0.8, minimist@~0.0.1:
 minimist@1.2.0, minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minipass@^2.2.1, minipass@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
+  integrity sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==
+  dependencies:
+    minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
   version "1.3.1"
@@ -3831,6 +4273,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -3838,6 +4285,11 @@ mute-stream@0.0.5:
 nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+
+nan@^2.9.2:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
+  integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
 nanoassert@^1.0.0:
   version "1.1.0"
@@ -3867,6 +4319,15 @@ nave@~0.5.1:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/nave/-/nave-0.5.3.tgz#5acec72375856e5c76c83bd21a68d713eb5f1ba4"
 
+needle@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
@@ -3882,6 +4343,27 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
 node-pre-gyp@^0.6.29:
   version "0.6.33"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz#640ac55198f6a925972e0c16c4ac26a034d5ecc9"
@@ -3896,18 +4378,25 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-nopt@~3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+node-releases@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.0.tgz#be7464fa8d877808237520fd49436d5e79191c3d"
+  integrity sha512-+qV91QMDBvARuPxUEfI/mRF/BY+UAkTIn3pvmvM2iOLIRvv6RNYklFXBgrkky6P1wXUqQW1P3qKlWxxy4JZbfg==
   dependencies:
-    abbrev "1"
+    semver "^5.3.0"
 
-nopt@~4.0.1:
+nopt@^4.0.1, nopt@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.3.2:
   version "2.3.6"
@@ -3922,6 +4411,33 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
+normalize-path@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+npm-bundled@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
+  integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
+
+npm-packlist@^1.1.6:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.12.tgz#22bde2ebc12e72ca482abd67afc51eb49377243a"
+  integrity sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+  dependencies:
+    path-key "^2.0.0"
+
 npmlog@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -3929,6 +4445,16 @@ npmlog@^4.0.1:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
     gauge "~2.7.1"
+    set-blocking "~2.0.0"
+
+npmlog@^4.0.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
     set-blocking "~2.0.0"
 
 null-check@^1.0.0:
@@ -3939,35 +4465,36 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^8.1.10:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-8.4.0.tgz#660371c807caef0427fb9b0948f74180624ea6e4"
+nyc@^13:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-13.1.0.tgz#463665c7ff6b5798e322624a5eb449a678db90e3"
+  integrity sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
-    caching-transform "^1.0.0"
-    convert-source-map "^1.3.0"
-    default-require-extensions "^1.0.0"
-    find-cache-dir "^0.1.1"
-    find-up "^1.1.2"
-    foreground-child "^1.5.3"
-    glob "^7.0.6"
-    istanbul-lib-coverage "^1.0.0"
-    istanbul-lib-hook "^1.0.0-alpha.4"
-    istanbul-lib-instrument "^1.2.0"
-    istanbul-lib-report "^1.0.0-alpha.3"
-    istanbul-lib-source-maps "^1.0.2"
-    istanbul-reports "^1.0.0"
-    md5-hex "^1.2.0"
-    micromatch "^2.3.11"
-    mkdirp "^0.5.0"
-    resolve-from "^2.0.0"
-    rimraf "^2.5.4"
-    signal-exit "^3.0.1"
-    spawn-wrap "^1.2.4"
-    test-exclude "^2.1.3"
-    yargs "^6.0.0"
-    yargs-parser "^4.0.2"
+    caching-transform "^2.0.0"
+    convert-source-map "^1.6.0"
+    debug-log "^1.0.1"
+    find-cache-dir "^2.0.0"
+    find-up "^3.0.0"
+    foreground-child "^1.5.6"
+    glob "^7.1.3"
+    istanbul-lib-coverage "^2.0.1"
+    istanbul-lib-hook "^2.0.1"
+    istanbul-lib-instrument "^3.0.0"
+    istanbul-lib-report "^2.0.2"
+    istanbul-lib-source-maps "^2.0.1"
+    istanbul-reports "^2.0.1"
+    make-dir "^1.3.0"
+    merge-source-map "^1.1.0"
+    resolve-from "^4.0.0"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    spawn-wrap "^1.4.2"
+    test-exclude "^5.0.0"
+    uuid "^3.3.2"
+    yargs "11.1.0"
+    yargs-parser "^9.0.2"
 
 oauth-sign@~0.8.1:
   version "0.8.2"
@@ -3977,7 +4504,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4068,17 +4595,20 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
   dependencies:
+    execa "^0.7.0"
     lcid "^1.0.0"
+    mem "^1.1.0"
 
 os-shim@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -4095,13 +4625,19 @@ outpipe@^1.1.0:
   dependencies:
     shell-quote "^1.4.2"
 
-output-file-sync@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
+output-file-sync@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
+  integrity sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==
   dependencies:
-    graceful-fs "^4.1.4"
+    graceful-fs "^4.1.11"
+    is-plain-obj "^1.1.0"
     mkdirp "^0.5.1"
-    object-assign "^4.1.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -4109,15 +4645,44 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  integrity sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
+  integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
+
+package-hash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/package-hash/-/package-hash-2.0.0.tgz#78ae326c89e05a4d813b68601977af05c00d2a0d"
+  integrity sha1-eK4ybIngWk2BO2hgGXevBcANKg0=
+  dependencies:
+    graceful-fs "^4.1.11"
+    lodash.flattendeep "^4.4.0"
+    md5-hex "^2.0.0"
+    release-zalgo "^1.0.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -4148,11 +4713,13 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
-parse-json@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
   dependencies:
-    error-ex "^1.2.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parsejson@0.0.3:
   version "0.0.3"
@@ -4188,23 +4755,27 @@ path-browserify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
 
-path-exists@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  dependencies:
-    pinkie-promise "^2.0.0"
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
-path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -4214,13 +4785,12 @@ path-platform@~0.11.15:
   version "0.11.15"
   resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
 
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.9"
@@ -4236,6 +4806,11 @@ pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -4246,11 +4821,26 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-pkg-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+pirates@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
+  integrity sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==
   dependencies:
-    find-up "^1.0.0"
+    node-modules-regexp "^1.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -4271,10 +4861,6 @@ preserve@^0.2.0:
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
-
-private@^0.1.7:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -4369,6 +4955,16 @@ raw-body@~2.2.0:
     iconv-lite "0.4.15"
     unpipe "1.0.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 rc@~1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.7.tgz#c5ea564bb07aff9fd3a5b32e906c1d3a65940fea"
@@ -4384,20 +4980,22 @@ read-only-stream@^2.0.0:
   dependencies:
     readable-stream "^2.0.2"
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+read-pkg-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
+  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
   dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
+    find-up "^3.0.0"
+    read-pkg "^3.0.0"
 
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
   dependencies:
-    load-json-file "^1.0.0"
+    load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
+    path-type "^3.0.0"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.1.0, readable-stream@^2.1.5:
   version "2.2.3"
@@ -4475,28 +5073,27 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-regenerate@^1.2.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
+regenerate-unicode-properties@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz#107405afcc4a190ec5ed450ecaa00ed0cafa7a4c"
+  integrity sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==
+  dependencies:
+    regenerate "^1.4.0"
+
+regenerate@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
+  integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
 
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-
-regenerator-runtime@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
-
-regenerator-transform@0.9.8:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.8.tgz#0f88bb2bc03932ddb7b6b7312e68078f01026d6c"
+regenerator-transform@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb"
+  integrity sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==
   dependencies:
-    babel-runtime "^6.18.0"
-    babel-types "^6.19.0"
     private "^0.1.6"
 
 regex-cache@^0.4.2:
@@ -4513,23 +5110,41 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpu-core@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
+regexpu-core@^4.1.3, regexpu-core@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.4.0.tgz#8d43e0d1266883969720345e70c275ee0aec0d32"
+  integrity sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==
   dependencies:
-    regenerate "^1.2.1"
-    regjsgen "^0.2.0"
-    regjsparser "^0.1.4"
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^7.0.0"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.0.2"
 
-regjsgen@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
+regjsgen@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
+  integrity sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==
 
-regjsparser@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
+regjsparser@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c"
+  integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
   dependencies:
     jsesc "~0.5.0"
+
+release-zalgo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
+  integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
+  dependencies:
+    es6-error "^4.0.1"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 rename-function-calls@~0.1.0:
   version "0.1.1"
@@ -4548,12 +5163,6 @@ repeat-string@^0.2.2:
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  dependencies:
-    is-finite "^1.0.0"
 
 replace-requires@~1.0.3:
   version "1.0.3"
@@ -4614,9 +5223,10 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve-from@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -4625,6 +5235,13 @@ resolve-url@^0.2.1:
 resolve@1.1.7, resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.3.2:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
+  dependencies:
+    path-parse "^1.0.5"
 
 resolve@~0.6.1:
   version "0.6.3"
@@ -4647,9 +5264,16 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.4.4, rimraf@^2.5.4, rimraf@^2.6.0:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@^2.6.1, rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
 
@@ -4681,11 +5305,26 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+safe-buffer@^5.1.2, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 secure-random@^1.1.1:
   version "1.1.1"
@@ -4699,7 +5338,7 @@ secure-random@~0.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@^5.6.0:
+semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
@@ -4764,6 +5403,18 @@ shasum@^1.0.0:
     json-stable-stringify "~0.0.0"
     sha.js "~2.4.4"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
 shell-quote@^1.4.2, shell-quote@^1.4.3, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
@@ -4785,25 +5436,18 @@ sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
-signal-exit@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-2.1.2.tgz#375879b1f92ebc3b334480d038dc546a6d558564"
-
-signal-exit@^3.0.0, signal-exit@^3.0.1:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-slide@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4892,27 +5536,17 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+source-map-support@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
   dependencies:
-    source-map "^0.5.6"
-
-source-map-support@^0.4.2:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.11.tgz#647f939978b38535909530885303daf23279f322"
-  dependencies:
-    source-map "^0.5.3"
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
-
-source-map@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  dependencies:
-    amdefine ">=0.0.4"
 
 source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
@@ -4921,6 +5555,11 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@~0.1.30:
   version "0.1.43"
@@ -4934,16 +5573,17 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
-spawn-wrap@^1.2.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.3.4.tgz#5d133070fef81cd26d8259acaa07fc1a86fd45dc"
+spawn-wrap@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
+  integrity sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==
   dependencies:
     foreground-child "^1.5.6"
     mkdirp "^0.5.0"
     os-homedir "^1.0.1"
-    rimraf "^2.3.3"
-    signal-exit "^2.0.0"
-    which "^1.2.4"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    which "^1.3.0"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -5030,7 +5670,7 @@ string-template@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -5044,6 +5684,14 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
+
+string-width@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
 
 string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"
@@ -5059,15 +5707,21 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
-    is-utf8 "^0.2.0"
+    ansi-regex "^3.0.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -5079,7 +5733,7 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-supports-color@3.1.2, supports-color@^3.1.2:
+supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5088,6 +5742,13 @@ supports-color@3.1.2, supports-color@^3.1.2:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
 
 syntax-error@^1.1.1:
   version "1.3.0"
@@ -5119,6 +5780,19 @@ tar-pack@~3.3.0:
     tar "~2.2.1"
     uid-number "~0.0.6"
 
+tar@^4:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
 tar@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -5131,24 +5805,14 @@ ternary@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ternary/-/ternary-1.0.0.tgz#45702725608c9499d46a9610e9b0e49ff26f789e"
 
-test-exclude@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-2.1.3.tgz#a8d8968e1da83266f9864f2852c55e220f06434a"
+test-exclude@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.0.0.tgz#cdce7cece785e0e829cd5c2b27baf18bc583cfb7"
+  integrity sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==
   dependencies:
     arrify "^1.0.1"
-    micromatch "^2.3.11"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
-    require-main-filename "^1.0.1"
-
-test-exclude@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
-  dependencies:
-    arrify "^1.0.1"
-    micromatch "^3.1.8"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
+    minimatch "^3.0.4"
+    read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
 text-table@~0.2.0:
@@ -5205,9 +5869,10 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -5286,13 +5951,21 @@ typeforce@^1.11.3:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.12.0.tgz#ca40899919f1466d7819e37be039406beb912a2e"
 
-uglify-js@2.x.x, uglify-js@^2.6:
+uglify-js@2.x.x:
   version "2.8.12"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.12.tgz#8a50f5d482243650b7108f6080aa3a6afe2a6c55"
   dependencies:
     source-map "~0.5.1"
     uglify-to-browserify "~1.0.0"
     yargs "~3.10.0"
+
+uglify-js@^3.1.4:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
+  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -5320,6 +5993,29 @@ umd@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
 
+unicode-canonical-property-names-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
+  integrity sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==
+
+unicode-match-property-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
+  integrity sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^1.0.4"
+    unicode-property-aliases-ecmascript "^1.0.4"
+
+unicode-match-property-value-ecmascript@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz#9f1dc76926d6ccf452310564fd834ace059663d4"
+  integrity sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==
+
+unicode-property-aliases-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
+  integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -5340,6 +6036,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+upath@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
+  integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -5356,10 +6057,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
     kind-of "^6.0.2"
-
-user-home@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
 user-home@^2.0.0:
   version "2.0.0"
@@ -5392,11 +6089,10 @@ uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-v8flags@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
-  dependencies:
-    user-home "^1.1.1"
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -5454,13 +6150,21 @@ whatwg-fetch@>=0.10.0, whatwg-fetch@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.11.1.tgz#6d3ded245fdd97cd728e0e2587b54b733949e663"
 
-which-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.1, which@^1.2.4, which@^1.2.9:
+which@^1.2.1, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
@@ -5508,13 +6212,14 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@^1.1.4:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.1.tgz#7d45ba32316328dd1ec7d90f60ebc0d845bb759a"
+write-file-atomic@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  integrity sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
-    slide "^1.1.5"
+    signal-exit "^3.0.2"
 
 write@^0.2.1:
   version "0.2.1"
@@ -5563,29 +6268,35 @@ yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^4.0.2, yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
-  dependencies:
-    camelcase "^3.0.0"
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs@^6.0.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
   dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
+    camelcase "^4.1.0"
+
+yargs@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
     decamelize "^1.1.1"
+    find-up "^2.1.0"
     get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
+    os-locale "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^4.2.0"
+    yargs-parser "^9.0.2"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
I have added more tests and removed dead code so now the coverage is FINALLY over 90% statements and travis FINALLY runs, after about 1 year

I have also added new babel and new nyc, which made the tests run MUCH faster (since the worker code is not babelified each time the worker is run, since it uses a babel cache). Negative - because Babel 7 does not have module-export-default thing, it might have broken something in mytrezor, will need to test later.

My plan now:

* increase the threshold to  95% branches and add more tests so the threshold is met (now we have 82% branches or something like that)
* maybe rewrite the bitcore.js tests so that it doesn't need to run bitcore in docker in the background
  * on one hand, I actually like that, it is testing actual conditions... 
  * on the other hand.... it is hard to write tests for that, since you need to actually send commands to underlying bitcore and bitcoind, and it takes forever to do anything
