### PR TITLE
Fix Flow error

### DIFF
--- a/src/bitcore.js
+++ b/src/bitcore.js
@@ -610,7 +610,12 @@ function observeErrors(socket: Socket): Stream<Error> {
     const errortypes = ['connect_error', 'reconnect_error', 'error', 'close', 'disconnect'];
     const streams = errortypes.map((type) => {
         const subs = socket.observe(type);
-        const cleaned = subs.map((k: mixed) => new Error(`${JSON.stringify(k)} (${type})`));
+        const cleaned = subs.map((k: mixed) => {
+            const stringify = JSON.stringify(k);
+            return new Error(`${
+                stringify !== undefined ? stringify : 'undefined'
+            } (${type})`);
+        });
         return cleaned;
     });
 


### PR DESCRIPTION
In later versions of Flow, the return type of `JSON.stringify` changed from `string` to `string | typeof undefinied` because `JSON.stringify(undefinied) === undefined`.

This PR simply gets rid of the Flow error