### PR TITLE
implement "required" utxo param, add "skipPermutation" param in buildTx

### DIFF
--- a/src/build-tx/coinselect-lib/index.js
+++ b/src/build-tx/coinselect-lib/index.js
@@ -8,7 +8,7 @@ import * as utils from './utils';
 import tryConfirmed from './tryconfirmed';
 
 export default function coinSelect(inputs, outputs, feeRate, options) {
-    const sortedInputs = inputs.sort(sorts.score(feeRate));
+    const sortedInputs = options.skipPermutation ? inputs : inputs.sort(sorts.score(feeRate));
 
     const algorithm = tryConfirmed(
         utils.anyOf([bnb(0.5), accumulative]),

--- a/src/build-tx/coinselect-lib/inputs/bnb.js
+++ b/src/build-tx/coinselect-lib/inputs/bnb.js
@@ -25,7 +25,9 @@ function calculateEffectiveValues(utxos, feeRate) {
 export default function branchAndBound(factor) {
     return (utxos, outputs, feeRate, options) => {
         const { inputLength, changeOutputLength } = options;
-        if (options.baseFee) return {}; // TEMP: disable bnb algorithm for DOGE
+        if (options.baseFee) return {}; // TODO: enable bnb algorithm for DOGE
+        // TODO: enable bnb algorithm if required utxos are defined
+        if (utxos.find(u => u.required)) return {};
 
         const feeRateBigInt = utils.bignumberOrNaN(feeRate);
         if (feeRateBigInt.isNaN() || !feeRateBigInt.isInteger()) return {};

--- a/src/build-tx/coinselect-lib/tryconfirmed.js
+++ b/src/build-tx/coinselect-lib/tryconfirmed.js
@@ -1,6 +1,6 @@
 function filterCoinbase(utxos, minConfCoinbase) {
     return utxos.filter((utxo) => {
-        if (utxo.coinbase) {
+        if (utxo.coinbase && !utxo.required) {
             return utxo.confirmations >= minConfCoinbase;
         }
         return true;
@@ -18,7 +18,7 @@ function filterUtxos(utxos, minConfOwn, minConfOther) {
             ? utxo.confirmations >= minConfOwn
             : utxo.confirmations >= minConfOther;
 
-        if (isUsed) {
+        if (isUsed || utxo.required) {
             usable.push(utxo);
         } else {
             unusable.push(utxo);

--- a/src/build-tx/coinselect.js
+++ b/src/build-tx/coinselect.js
@@ -150,6 +150,7 @@ function convertInputs(
         confirmations: input.height == null
             ? 0
             : (1 + height - input.height),
+        required: input.required,
     }));
 }
 

--- a/src/build-tx/coinselect.js
+++ b/src/build-tx/coinselect.js
@@ -84,6 +84,7 @@ export function coinselect(
     floorBaseFee?: boolean,
     dustOutputFee?: number,
     skipUtxoSelection?: boolean,
+    skipPermutation?: boolean,
 ): Result {
     const inputs = convertInputs(utxos, height, segwit);
     const outputs = convertOutputs(rOutputs, network);
@@ -94,6 +95,7 @@ export function coinselect(
         baseFee,
         floorBaseFee,
         dustOutputFee,
+        skipPermutation,
     };
 
     const algorithm = countMax ? bitcoinJsSplit : bitcoinJsCoinselect;

--- a/src/build-tx/index.js
+++ b/src/build-tx/index.js
@@ -27,6 +27,7 @@ export function buildTx(
         floorBaseFee,
         dustOutputFee,
         skipUtxoSelection,
+        skipPermutation,
     }: request.Request,
 ): result.Result {
     if (outputs.length === 0) {
@@ -60,6 +61,7 @@ export function buildTx(
             floorBaseFee,
             dustOutputFee,
             skipUtxoSelection,
+            skipPermutation,
         );
     } catch (e) {
         return { type: 'error', error: e.message };
@@ -83,6 +85,7 @@ export function buildTx(
         changeId,
         changeAddress,
         network,
+        skipPermutation,
     );
     return result.getFinalResult(csResult, resTransaction);
 }

--- a/src/build-tx/request.js
+++ b/src/build-tx/request.js
@@ -45,6 +45,7 @@ export type Request = {
     floorBaseFee?: boolean; // DOGE floor base fee to the nearest integer
     dustOutputFee?: number; // DOGE fee for every output below dust limit
     skipUtxoSelection?: boolean; // use custom utxo selection, without algorithm
+    skipPermutation?: boolean; // Do not sort inputs/outputs and preserve the given order. Handy for RBF.
 };
 
 export function splitByCompleteness(

--- a/src/build-tx/transaction.js
+++ b/src/build-tx/transaction.js
@@ -59,6 +59,7 @@ export function createTransaction(
     changeId: number,
     changeAddress: string,
     network: BitcoinJsNetwork,
+    skipPermutation?: boolean,
 ): Transaction {
     const convertedInputs = selectedInputs.map((input) => {
         const { id } = input;
@@ -94,6 +95,15 @@ export function createTransaction(
             segwit,
         );
     });
+
+    // this syntax is forced by flow: sketchy-null-bool
+    // i don't like it but needs to be refactored anyway...
+    if (skipPermutation === true) {
+        return {
+            inputs: convertedInputs,
+            outputs: new Permutation(convertedOutputs.map(o => o.output), convertedOutputs.map((_o, i) => i))
+        }
+    }
     convertedInputs.sort((a, b) => inputComparator(a.hash, a.index, b.hash, b.index));
     const permutedOutputs = Permutation.fromFunction(convertedOutputs, (a, b) => {
         const aValue: string = typeof a.output.value === 'string' ? a.output.value : '0';

--- a/test/build-tx.js
+++ b/test/build-tx.js
@@ -39,6 +39,7 @@ describe('build tx', () => {
                     }
                 });
                 result.transaction.outputs = new Permutation(sorted, o.permutation);
+
                 delete result.transaction.PERM_outputs;
             }
             assert.deepStrictEqual(buildTx(request), result);

--- a/test/fixtures/build-tx.json
+++ b/test/fixtures/build-tx.json
@@ -1883,5 +1883,92 @@
       },
       "type": "final"
     }
+  },
+  {
+    "description": "skip inputs/outputs permutation",
+    "request": {
+      "basePath": [44, 1, 0],
+      "changeAddress": "1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT",
+      "changeId": 1,
+      "dustThreshold": 546,
+      "feeRate": "10",
+      "height": 100,
+      "inputAmounts": true,
+      "skipPermutation": true,
+      "outputs": [
+        {
+          "address": "1BitcoinEaterAddressDontSendf59kuE",
+          "amount": "70000",
+          "type": "complete"
+        }
+      ],
+      "segwit": false,
+      "utxos": [
+        {
+          "addressPath": [1, 0],
+          "fee": "0",
+          "height": 60,
+          "index": 0,
+          "transactionHash": "a4dc0ffeee",
+          "tsize": 0,
+          "value": "65291",
+          "vsize": 0,
+          "coinbase": false,
+          "own": false
+        },
+        {
+          "addressPath": [1, 1],
+          "fee": "0",
+          "height": 50,
+          "index": 1,
+          "transactionHash": "b4dc0ffeee",
+          "tsize": 0,
+          "value": "55291",
+          "vsize": 0,
+          "coinbase": false,
+          "own": false
+        }
+      ]
+    },
+    "result": {
+      "bytes": 379,
+      "fee": "3790",
+      "feePerByte": "10",
+      "max": -1,
+      "totalSpent": "73790",
+      "transaction": {
+        "PERM_outputs": {
+          "permutation": [0, 1],
+          "sorted": [
+            {
+              "address": "1BitcoinEaterAddressDontSendf59kuE",
+              "value": "70000"
+            },
+            {
+              "value": "46792",
+              "path": [44, 1, 0, 1, 1],
+              "segwit": false
+            }
+          ]
+        },
+        "inputs": [
+          {
+            "REV_hash": "a4dc0ffeee",
+            "index": 0,
+            "amount": "65291",
+            "path": [44, 1, 0, 1, 0],
+            "segwit": false
+          },
+          {
+            "REV_hash": "b4dc0ffeee",
+            "index": 1,
+            "amount": "55291",
+            "path": [44, 1, 0, 1, 1],
+            "segwit": false
+          }
+        ]
+      },
+      "type": "final"
+    }
   }
 ]

--- a/test/fixtures/build-tx.json
+++ b/test/fixtures/build-tx.json
@@ -1772,5 +1772,116 @@
       },
       "type": "final"
     }
+  },
+  {
+    "description": "use required (coinbase + unconfirmed) instead of more suitable utxo",
+    "request": {
+      "basePath": [44, 1, 0],
+      "changeAddress": "1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT",
+      "changeId": 1,
+      "dustThreshold": 546,
+      "feeRate": "10",
+      "height": 200,
+      "inputAmounts": true,
+      "outputs": [
+        {
+          "address": "1BitcoinEaterAddressDontSendf59kuE",
+          "amount": "100000",
+          "type": "complete"
+        }
+      ],
+      "segwit": false,
+      "utxos": [
+        {
+          "addressPath": [1, 0],
+          "fee": "0",
+          "height": 200,
+          "index": 0,
+          "transactionHash": "a4dc0ffeee",
+          "tsize": 0,
+          "value": "65291",
+          "vsize": 0,
+          "coinbase": true,
+          "own": false,
+          "required": true
+        },
+        {
+          "addressPath": [0, 1],
+          "fee": "0",
+          "height": 150,
+          "index": 0,
+          "transactionHash": "c4dc0ffeee",
+          "tsize": 0,
+          "value": "202001",
+          "coinbase": false,
+          "own": true,
+          "vsize": 0
+        },
+        {
+          "addressPath": [1, 1],
+          "fee": "0",
+          "index": 0,
+          "transactionHash": "b4dc0ffeee",
+          "tsize": 0,
+          "value": "55291",
+          "vsize": 0,
+          "coinbase": false,
+          "own": false,
+          "required": true
+        },
+        {
+          "addressPath": [0, 2],
+          "fee": "0",
+          "height": 100,
+          "index": 0,
+          "transactionHash": "d4dc0ffeee",
+          "tsize": 0,
+          "value": "200000",
+          "coinbase": false,
+          "own": true,
+          "vsize": 0
+        }
+      ]
+    },
+    "result": {
+      "bytes": 379,
+      "fee": "3790",
+      "feePerByte": "10",
+      "max": -1,
+      "totalSpent": "103790",
+      "transaction": {
+        "PERM_outputs": {
+          "permutation": [1, 0],
+          "sorted": [
+            {
+              "value": "16792",
+              "path": [44, 1, 0, 1, 1],
+              "segwit": false
+            },
+            {
+              "address": "1BitcoinEaterAddressDontSendf59kuE",
+              "value": "100000"
+            }
+          ]
+        },
+        "inputs": [
+          {
+            "REV_hash": "a4dc0ffeee",
+            "index": 0,
+            "amount": "65291",
+            "path": [44, 1, 0, 1, 0],
+            "segwit": false
+          },
+          {
+            "REV_hash": "b4dc0ffeee",
+            "index": 0,
+            "amount": "55291",
+            "path": [44, 1, 0, 1, 1],
+            "segwit": false
+          }
+        ]
+      },
+      "type": "final"
+    }
   }
 ]


### PR DESCRIPTION
- [required utxo](https://github.com/trezor/hd-wallet/commit/db0d5e41c7e92c083f6c00dfeff8eed93b8361c2) was added in the accumulative algorithm, yet it was not exposed to the `buildTx` index

- added `skipPermutation` option, useful in RBF transactions where manipulating with inputs/outputs order is not desired